### PR TITLE
A fix for HDBEditor crash when adding empty FU architecture

### DIFF
--- a/tce/src/applibs/hdb/HDBManager.cc
+++ b/tce/src/applibs/hdb/HDBManager.cc
@@ -561,6 +561,7 @@ HDBManager::addFUArchitecture(const FUArchitecture& arch) const
     // check the operand bindings of the FU
     FunctionUnit& fu = arch.architecture();
     MachineValidatorResults results;
+    FUValidator::checkOperations(fu, results);
     FUValidator::checkOperandBindings(fu, results);
     if (results.errorCount() > 0) {
         throw InvalidData(

--- a/tce/src/applibs/mach/FUValidator.cc
+++ b/tce/src/applibs/mach/FUValidator.cc
@@ -118,9 +118,7 @@ FUValidator::checkOperations(
         }
     }
 
-    boost::format errorMsg(
-                    "FU %1% has no valid operations.");
-                errorMsg % fu.name();
-                results.addError(
-                    MachineValidator::RF_NO_VALID_OPERATIONS, errorMsg.str());
+    boost::format errorMsg("FU %1% has no valid operations.");
+    errorMsg % fu.name();
+    results.addError(MachineValidator::FU_NO_VALID_OPERATIONS, errorMsg.str());
 }

--- a/tce/src/applibs/mach/FUValidator.cc
+++ b/tce/src/applibs/mach/FUValidator.cc
@@ -122,5 +122,5 @@ FUValidator::checkOperations(
                     "FU %1% has no valid operations.");
                 errorMsg % fu.name();
                 results.addError(
-                    MachineValidator::USED_IO_NOT_BOUND, errorMsg.str());
+                    MachineValidator::RF_NO_VALID_OPERATIONS, errorMsg.str());
 }

--- a/tce/src/applibs/mach/FUValidator.cc
+++ b/tce/src/applibs/mach/FUValidator.cc
@@ -39,6 +39,7 @@
 #include "FunctionUnit.hh"
 #include "ExecutionPipeline.hh"
 #include "HWOperation.hh"
+#include "FUPort.hh"
 
 using namespace TTAMachine;
 
@@ -85,4 +86,41 @@ FUValidator::checkOperandBindings(
             }
         }
     }
+}
+
+
+/**
+ * Checks that the FU has at least one operation which is valid, i.e.
+ * has at least one triggering input port
+ *
+ * @param fu The function unit.
+ * @param results Results of the validation are added to the given instance.
+ */
+void
+FUValidator::checkOperations(
+    const TTAMachine::FunctionUnit& fu,
+    MachineValidatorResults& results) {
+
+    for (int i = 0; i < fu.operationCount(); i++) {
+        HWOperation* operation = fu.operation(i);
+        ExecutionPipeline* pLine = operation->pipeline();
+        ExecutionPipeline::OperandSet usedOperands;
+        for (int i = 0; i < pLine->latency(); i++) {
+            ExecutionPipeline::OperandSet readOperands =
+                pLine->readOperands(i);
+            for (ExecutionPipeline::OperandSet::const_iterator iter =
+                    readOperands.begin(); iter != readOperands.end(); iter++) {
+                FUPort* port = operation->port(*iter);
+                if (port != NULL && port->isTriggering()) {
+                    return;
+                }
+            }
+        }
+    }
+
+    boost::format errorMsg(
+                    "FU %1% has no valid operations.");
+                errorMsg % fu.name();
+                results.addError(
+                    MachineValidator::USED_IO_NOT_BOUND, errorMsg.str());
 }

--- a/tce/src/applibs/mach/FUValidator.hh
+++ b/tce/src/applibs/mach/FUValidator.hh
@@ -47,6 +47,9 @@ public:
     static void checkOperandBindings(
         const TTAMachine::FunctionUnit& fu,
         MachineValidatorResults& results);
+    static void checkOperations(
+        const TTAMachine::FunctionUnit& fu,
+        MachineValidatorResults& results);
 
 private:
     FUValidator();

--- a/tce/src/applibs/mach/MachineValidator.hh
+++ b/tce/src/applibs/mach/MachineValidator.hh
@@ -68,7 +68,9 @@ public:
         /// RA and PC ports have unequal width.
         PC_AND_RA_PORTS_HAVE_UNEQUAL_WIDTH,
         /// Instruction memory address width differs from PC/RA port width.
-        IMEM_ADDR_WIDTH_DIFFERS_FROM_RA_AND_PC
+        IMEM_ADDR_WIDTH_DIFFERS_FROM_RA_AND_PC,
+        /// RF has no operations with a trigger
+        RF_NO_VALID_OPERATIONS
     };
 
     MachineValidator(const TTAMachine::Machine& machine);

--- a/tce/src/applibs/mach/MachineValidator.hh
+++ b/tce/src/applibs/mach/MachineValidator.hh
@@ -69,8 +69,8 @@ public:
         PC_AND_RA_PORTS_HAVE_UNEQUAL_WIDTH,
         /// Instruction memory address width differs from PC/RA port width.
         IMEM_ADDR_WIDTH_DIFFERS_FROM_RA_AND_PC,
-        /// RF has no operations with a trigger
-        RF_NO_VALID_OPERATIONS
+        /// FU has no operations with a trigger
+        FU_NO_VALID_OPERATIONS
     };
 
     MachineValidator(const TTAMachine::Machine& machine);


### PR DESCRIPTION
HDBEditor will no longer crash when adding, through Edit->Add->FU Architecture From ADF..., an FU architecture without any triggerable operation.