### PR TITLE
Fixed FU port width/generic mismatch, tweaked debugger ifetch

### DIFF
--- a/tce/data/ProGe/debugfetch.vhdl.tmpl
+++ b/tce/data/ProGe/debugfetch.vhdl.tmpl
@@ -111,7 +111,8 @@ begin
   imem_addr <= pc_reg when (lock = '0')   else pc_prev_reg;
 
   -- propagate lock to global lock
-  glock      <= busy or reset_lock or (not (fetch_en or no_glock_loopback_g));
+  glock      <= not db_rstx or busy or reset_lock
+                or (not (fetch_en or no_glock_loopback_g));
   ra_out     <= return_addr_reg;
   fetchblock <= instruction_reg;
 
@@ -151,7 +152,7 @@ begin
         return_addr_reg <= (others => '0');
         instruction_reg <= (others => '0');
         reset_cntr      <= 0;
-        reset_lock      <= '0';
+        reset_lock      <= '1';
         cyclecnt        <= (others => '0');
       elsif lock = '0' then
         if fetch_en = '1' then


### PR DESCRIPTION
HDB edit: FU IDs 34-39 and 180-187 (eq(1), gt(1), gtu(1) and eq(2), gt(2), gtu(2)) had a non-parametric output port width of 1 bit, but the corresponding generic was set to 32 bits in every implementation. Set generic to 1.