### PR TITLE
added another patch for 3.8

### DIFF
--- a/tce/tools/patches/llvm-3.8-llvmprefixpatch.patch
+++ b/tce/tools/patches/llvm-3.8-llvmprefixpatch.patch
@@ -1,0 +1,16 @@
+Index: tools/clang/lib/Driver/ToolChains.cpp
+===================================================================
+--- tools/clang/lib/Driver/ToolChains.cpp
++++ tools/clang/lib/Driver/ToolChains.cpp
+@@ -2607,9 +2607,11 @@
+   if (getVFS().exists(InstallRelDir = InstalledDir + "/../target"))
+     return InstallRelDir;
+ 
++#ifdef LLVM_PREFIX
+   std::string PrefixRelDir = std::string(LLVM_PREFIX) + "/target";
+   if (getVFS().exists(PrefixRelDir))
+     return PrefixRelDir;
++#endif
+ 
+   return InstallRelDir;
+ }

--- a/tce/tools/scripts/install_llvm_3.8.sh
+++ b/tce/tools/scripts/install_llvm_3.8.sh
@@ -73,6 +73,7 @@ function apply_patches {
     try_patch $patch_dir/llvm-3.8-tce-and-tcele.patch
     try_patch $patch_dir/llvm-3.8-memcpyoptimizer-only-on-default-as.patch
     try_patch $patch_dir/llvm-3.8-loopidiomrecognize-only-on-default-as.patch
+    try_patch $patch_dir/llvm-3.8-llvmprefixpatch.patch
     cd ..
 }
 


### PR DESCRIPTION
this patch fixes a compile issue with 3.8 where it fails if LLVM_PREFIX is not set