### PR TITLE
Write rights are no longer needed for hdb's

### DIFF
--- a/tce/src/applibs/hdb/HDBManager.cc
+++ b/tce/src/applibs/hdb/HDBManager.cc
@@ -354,8 +354,8 @@ HDBManager::HDBManager(const std::string& hdbFile)
         throw FileNotFound(__FILE__, __LINE__, __func__, errorMsg);
     }
 
-    if (!FileSystem::fileIsWritable(hdbFile)) {
-        string errorMsg = "File '" + hdbFile + "' is not writable.";
+    if (!FileSystem::fileIsReadable(hdbFile)) {
+        string errorMsg = "File '" + hdbFile + "' has no read rights.";
         throw IOException(__FILE__, __LINE__, __func__, errorMsg);
     }
 

--- a/tce/src/codesign/Explorer/Explorer.cc
+++ b/tce/src/codesign/Explorer/Explorer.cc
@@ -746,9 +746,6 @@ int main(int argc, char* argv[]) {
             } catch (const FileNotFound& e) {
                 std::cerr << "Could not find HDB file " 
                           << options->hdbFileName(i) << std::endl;
-            } catch (const IOException& e) {
-                std::cerr << "HDB file " << options->hdbFileName(i)
-                          << " is not writable." << std::endl;
             }
         }
     } else {
@@ -764,20 +761,11 @@ int main(int argc, char* argv[]) {
                 break;
             }
         }
-
         try {
-            if (!FileSystem::fileIsWritable(pathToHdb)) {
-                std::cerr << "HDB file " << pathToHdb << " is not writable."
-                          << std::endl;
-            } else {
-                HDB::HDBRegistry::instance().hdb(pathToHdb);
-            }
+            HDB::HDBRegistry::instance().hdb(pathToHdb);
         } catch (const FileNotFound& e) {
             std::cerr << "Could not find HDB file " 
                       << pathToHdb << std::endl;
-        } catch (const IOException& e) {
-            std::cerr << "HDB file " << pathToHdb
-                      << " is not writable." << std::endl;
         }
     }
     


### PR DESCRIPTION
- Changed HDBManager policy to just check if hdb file has read access (instead of readwrite) 
- Removed IO exception checks (thrown by HDBManager) from Explorer ()

Still somekind of logic should be implemented to check if hdb file is writable, when its contents are modified. At this moment it just crashes.