### PR TITLE
Fixed compilation error in wxwidgets 2.8

### DIFF
--- a/tce/src/codesign/Proxim/ProximDebuggerWindow.cc
+++ b/tce/src/codesign/Proxim/ProximDebuggerWindow.cc
@@ -132,7 +132,8 @@ ProximDebuggerWindow::updateAnnotations() {
         const TTAProgram::Move& m = instruction.move(i);
 
         if (m.hasSourceLineNumber()) {
-            if (m.sourceFileName() == currentFile_) {
+            wxString sourceFile = WxConversion::toWxString(m.sourceFileName());
+            if (sourceFile == currentFile_) {
                 highlightLine(m.sourceLineNumber());
             }
         }


### PR DESCRIPTION
In the last Proxim debugger window update PR I forgot to test it on wxwidgets 2.8, which did not compiled. Now the problem should be solved.