### PR TITLE
Some ghdl 0.33 issues

### DIFF
--- a/tce/hdb/fpu_embedded_vhdl/fixed_pkg_c.vhdl
+++ b/tce/hdb/fpu_embedded_vhdl/fixed_pkg_c.vhdl
@@ -2239,24 +2239,26 @@ end SYS_fmod;
   function to_slv (
     arg : UNRESOLVED_ufixed)            -- fixed point vector
     return STD_LOGIC_VECTOR is
-    variable result : STD_LOGIC_VECTOR (arg'length-1 downto 0);
+    subtype result_subtype is std_logic_vector (arg'length-1 downto 0);
+    variable result : result_subtype;
   begin
     if arg'length < 1 then
       return NSLV;
     end if;
-    result := STD_LOGIC_VECTOR (arg);
+    result := result_subtype (arg);
     return result;
   end function to_slv;
 
   function to_slv (
     arg : UNRESOLVED_sfixed)            -- fixed point vector
     return STD_LOGIC_VECTOR is
-    variable result : STD_LOGIC_VECTOR (arg'length-1 downto 0);
+    subtype result_subtype is std_logic_vector (arg'length-1 downto 0);
+    variable result : result_subtype;
   begin
     if arg'length < 1 then
       return NSLV;
     end if;
-    result := STD_LOGIC_VECTOR (arg);
+    result := result_subtype (arg);
     return result;
   end function to_slv;
 

--- a/tce/hdb/fpu_embedded_vhdl/float_pkg_c.vhdl
+++ b/tce/hdb/fpu_embedded_vhdl/float_pkg_c.vhdl
@@ -1457,12 +1457,13 @@ package body float_pkg is
   function to_slv (
     arg : UNRESOLVED_float)             -- fp vector
     return STD_LOGIC_VECTOR is
-    variable result : STD_LOGIC_VECTOR (arg'length-1 downto 0);
+    subtype result_subtype is STD_LOGIC_VECTOR (arg'length-1 downto 0);
+    variable result : result_subtype;
   begin  -- function to_STD_LOGIC_vector
     if arg'length < 1 then
       return NSLV;
     end if;
-    result := STD_LOGIC_VECTOR (arg);
+    result := result_subtype (arg);
     return result;
   end function to_slv;
 

--- a/tce/hdb/fpu_half_vhdl/float_pkg_tce.vhdl
+++ b/tce/hdb/fpu_half_vhdl/float_pkg_tce.vhdl
@@ -211,9 +211,10 @@ package body float_pkg_tce is
   function to_suv (
     arg : UNRESOLVED_float)             -- fp vector
     return STD_ULOGIC_VECTOR is
-    variable result : STD_ULOGIC_VECTOR (arg'length-1 downto 0);
+    subtype result_subtype is STD_ULOGIC_VECTOR (arg'length-1 downto 0);
+    variable result : result_subtype;
   begin  -- function to_std_ulogic_vector
-    result := STD_ULOGIC_VECTOR (arg);
+    result := result_subtype (arg);
     return result;
   end function to_suv;
 

--- a/testsuite/systemtest_long/procgen/PlatformIntegrator/AlmaIFIntegrator/almaif_integrator/1_output.txt
+++ b/testsuite/systemtest_long/procgen/PlatformIntegrator/AlmaIFIntegrator/almaif_integrator/1_output.txt
@@ -1,4 +1,3 @@
-./vhdl/rf_1wr_1rd_always_1_guarded_1.vhd:109:32:warning: universal integer bound must be numeric literal or attribute
 analyze ./vhdl/almaif_core_imem_mau_pkg.vhdl
 analyze ./vhdl/almaif_core_globals_pkg.vhdl
 analyze ./vhdl/tce_util_pkg.vhdl
@@ -21,7 +20,6 @@ analyze ./vhdl/util_pkg.vhdl
 analyze ./vhdl/monolithic_alu_shladd_small.vhdl
 analyze ./vhdl/rf_1wr_1rd_always_1_guarded_0.vhd
 analyze ./vhdl/rf_1wr_1rd_always_1_guarded_1.vhd
-./vhdl/rf_1wr_1rd_always_1_guarded_1.vhd:109:32:warning: universal integer bound must be numeric literal or attribute
 analyze ./gcu_ic/ic.vhdl
 analyze ./gcu_ic/input_socket_1.vhdl
 analyze ./gcu_ic/output_socket_3_1.vhdl

--- a/testsuite/systemtest_long/procgen/PlatformIntegrator/AlmaIFIntegrator/tcetest_almaif_integrator.sh
+++ b/testsuite/systemtest_long/procgen/PlatformIntegrator/AlmaIFIntegrator/tcetest_almaif_integrator.sh
@@ -42,7 +42,11 @@ then
   find -name "*.vhd"  -exec ghdl -i --workdir=work {} \;
 
   ghdl -i --workdir=work ../data/tta-almaif-tb.vhdl
-  ghdl -m --workdir=work --ieee=synopsys -fexplicit --warn-no-unused --warn-no-specs tta_almaif_tb
+  ghdl -m --workdir=work --ieee=synopsys -fexplicit --warn-no-unused tta_almaif_tb 2>errors
+
+
+  # Remove an expected error which reports a different column with different GHDL versions
+  cat errors | grep -v "universal integer bound must be numeric literal or attribute"
 
   ./tta_almaif_tb --stop-time=1500us 2>/dev/null || eexit "Simulation failed"
 


### PR DESCRIPTION
- The FP packages' conversion functions to std_(u)logic_vector failed to compile on ghdl 0.33, workaround added.
- The AlmaIFIntegrator test would fail on ghdl 0.33 due to different column number in a benign error message. To preserve compatibility with earlier versions, the error is now grep'd out.