### PR TITLE
Fixed broken bp and cmd history windows in Proxim

### DIFF
--- a/tce/src/codesign/Proxim/ProximMainFrame.cc
+++ b/tce/src/codesign/Proxim/ProximMainFrame.cc
@@ -91,7 +91,7 @@ BEGIN_EVENT_TABLE(ProximMainFrame, wxFrame)
         ProximConstants::COMMAND_LAST,
         ProximMainFrame::onCommandEvent)
     EVT_MENU_RANGE(ProximConstants::COMMAND_TOGGLE_CONSOLE_WIN,
-        ProximConstants::COMMAND_TOGGLE_DEBUGGER_WIN,
+        ProximConstants::COMMAND_TOGGLE_BREAKPOINT_WIN,
         ProximMainFrame::onToggleWindow)
     EVT_MENU(UserManualCmd::COMMAND_ID, ProximMainFrame::onCommandEvent)
     EVT_COMMAND_RANGE(ProximConstants::COMMAND_FIRST,
@@ -103,7 +103,7 @@ BEGIN_EVENT_TABLE(ProximMainFrame, wxFrame)
         ProximMainFrame::updateCommand)
 
     EVT_UPDATE_UI_RANGE(ProximConstants::COMMAND_TOGGLE_CONSOLE_WIN,
-        ProximConstants::COMMAND_TOGGLE_DEBUGGER_WIN,
+        ProximConstants::COMMAND_TOGGLE_BREAKPOINT_WIN,
         ProximMainFrame::updateToggleItem)
 
     EVT_SIMULATOR_START(0, ProximMainFrame::onSimulatorEvent)


### PR DESCRIPTION
Some commands left out of wx event range and it was impossible to launch breakpoint and command history windows in Proxim. Now the problem is fixed.