### PR TITLE
Fixed OSEd OperationDAGDialog scaling on resize

### DIFF
--- a/tce/src/codesign/osal/OSEd/OperationDAGDialog.cc
+++ b/tce/src/codesign/osal/OSEd/OperationDAGDialog.cc
@@ -534,14 +534,14 @@ OperationDAGDialog::createContents(
     wxTextCtrl* editDAG =
         new wxTextCtrl(
                 parent, ID_EDIT_DAG, wxT(""), wxDefaultPosition,
-                wxSize(250,365), wxTE_MULTILINE);
+                wxSize(250,-1), wxTE_MULTILINE);
 
     // Static box for DAG image
     wxStaticBox *dagImageStaticBox = new wxStaticBox(parent, -1, wxT("DAG"));
     dagImageStaticBoxSizer_ =
         new wxStaticBoxSizer(dagImageStaticBox, wxVERTICAL);
 
-    dagImageStaticBoxSizer_->Add(dagWindow_, 5, wxALIGN_TOP|wxALL|wxGROW, 5);
+    dagImageStaticBoxSizer_->Add(dagWindow_, 1, wxALIGN_TOP|wxALL|wxGROW, 5);
     dagImageStaticBoxSizer_->SetDimension(-1, -1, 550, 550);
 
     // DAG image
@@ -554,15 +554,15 @@ OperationDAGDialog::createContents(
     dagImageStaticBoxSizer_->Show(true);
 
     // Add DAG editor to DAG code sizer
-    dagStaticBoxSizer->Add(editDAG, 0, wxALIGN_TOP|wxALL|wxGROW, 5);
+    dagStaticBoxSizer->Add(editDAG, 1, wxALIGN_TOP|wxALL|wxGROW, 5);
     
     // Add DAG code to page sizer
     wxBoxSizer *pageSizer = new wxBoxSizer(wxHORIZONTAL);
-    pageSizer->Add(dagStaticBoxSizer, 0, wxALIGN_TOP|wxTOP, 10);
-    pageSizer->Add(dagImageStaticBoxSizer_, 0, wxALIGN_TOP|wxTOP, 10);
+    pageSizer->Add(dagStaticBoxSizer, 1, wxALIGN_TOP|wxGROW|wxTOP, 10);
+    pageSizer->Add(dagImageStaticBoxSizer_, 2, wxALIGN_TOP|wxGROW|wxTOP, 10);
 
     // Add page sizer to window sizer
-    item0->Add(pageSizer, 0, wxALIGN_CENTER|wxALL, 5);
+    item0->Add(pageSizer, 1, wxALIGN_CENTER|wxEXPAND|wxALL, 5);
 
     wxString strs9[] = 
         {
@@ -631,4 +631,3 @@ OperationDAGDialog::createContents(
     
     return item0;
 }
-


### PR DESCRIPTION
* OSEd DAG graph window size adjustment now scales correctly on resize