### PR TITLE
Add a patch to update TCE address space numbers in Clang to match SPIR

### DIFF
--- a/tce/tools/patches/llvm-6.0-SPIR-address-space-numbers.patch
+++ b/tce/tools/patches/llvm-6.0-SPIR-address-space-numbers.patch
@@ -1,0 +1,17 @@
+Index: tools/clang/lib/Basic/Targets/TCE.h
+===================================================================
+--- tools/clang/lib/Basic/Targets/TCE.h
++++ tools/clang/lib/Basic/Targets/TCE.h
+@@ -32,9 +32,9 @@ namespace targets {
+ 
+ static const unsigned TCEOpenCLAddrSpaceMap[] = {
+     0, // Default
+-    3, // opencl_global
+-    4, // opencl_local
+-    5, // opencl_constant
++    1, // opencl_global
++    3, // opencl_local
++    2, // opencl_constant
+     0, // opencl_private
+     // FIXME: generic has to be added to the target
+     0, // opencl_generic

--- a/tce/tools/scripts/install_llvm_6.0.sh
+++ b/tce/tools/scripts/install_llvm_6.0.sh
@@ -72,6 +72,7 @@ function apply_patches {
     cd $llvm_co_dir
     try_patch $patch_dir/llvm-6.0-custom-vector-extension.patch
     try_patch $patch_dir/llvm-6.0-vect-datalayout.patch
+    try_patch $patch_dir/llvm-6.0-SPIR-address-space-numbers.patch
     cd ..
 }
 


### PR DESCRIPTION
This is for https://github.com/pocl/pocl/pull/641