### PR TITLE
Fix #73 - compiling with GCC 8.x

### DIFF
--- a/tce/src/base/program/ProgramOperation.cc
+++ b/tce/src/base/program/ProgramOperation.cc
@@ -655,6 +655,13 @@ ProgramOperation::Comparator::operator()(
     return po1->poId() < po2->poId();
 }
 
+bool
+ProgramOperation::Comparator::operator()(
+    const ProgramOperationPtr &po1, const ProgramOperationPtr &po2) const {
+    return po1.get()->poId() < po2.get()->poId();
+}
+
+
 /**
  * Switches inputs of 2-operand commutative operations
  */

--- a/tce/src/base/program/ProgramOperation.hh
+++ b/tce/src/base/program/ProgramOperation.hh
@@ -44,6 +44,7 @@
 class MoveNode;
 class MoveNodeSet;
 class Operation;
+class ProgramOperation;
 
 namespace llvm {
     class MachineInstr;
@@ -51,6 +52,11 @@ namespace llvm {
 namespace TTAProgram {
     class Move;
 }
+
+// use this smart_ptr type to point to POs to allow more safe sharing of
+// POs between POM and DDG, etc.
+typedef boost::shared_ptr<ProgramOperation> ProgramOperationPtr;
+
 
 /**
  * Represents a single execution of an operation in a program.
@@ -113,6 +119,9 @@ public:
     public:
         bool operator()(
             const ProgramOperation* po1, const ProgramOperation* po2) const;
+        bool operator()(
+            const ProgramOperationPtr &po1, const ProgramOperationPtr &po2) const;
+
     };
 
 private:
@@ -136,10 +145,6 @@ private:
     // Reference to original LLVM MachineInstruction
     const llvm::MachineInstr* mInstr_;
 };
-
-// use this smart_ptr type to point to POs to allow more safe sharing of
-// POs between POM and DDG, etc.
-typedef boost::shared_ptr<ProgramOperation> ProgramOperationPtr;
 
 class ProgramOperationPtrComparator {
 public:


### PR DESCRIPTION
Adds a new overload for ProgramOperation::Comparator with ProgramOperationPtr arguments.

FWIW, it's possible that this PR is entirely wrong, since i'm not too familiar with the code :) but it seems to fix the issue.
