### PR TITLE
Release fixes

### DIFF
--- a/tce/data/mach/minimal.adf
+++ b/tce/data/mach/minimal.adf
@@ -133,27 +133,6 @@
     </writes-to>
   </socket>
 
-  <socket name="rotator_i1">
-    <reads-from>
-      <bus>B1</bus>
-      <segment>seg1</segment>
-    </reads-from>
-  </socket>
-
-  <socket name="rotator_i2">
-    <reads-from>
-      <bus>B1</bus>
-      <segment>seg1</segment>
-    </reads-from>
-  </socket>
-
-  <socket name="rotator_o1">
-    <writes-to>
-      <bus>B1</bus>
-      <segment>seg1</segment>
-    </writes-to>
-  </socket>
-
   <socket name="RF_i1">
     <reads-from>
       <bus>B1</bus>
@@ -539,14 +518,14 @@
 
   <function-unit name="shifter">
     <port name="in1t">
-      <connects-to>shifter_i1</connects-to>
-      <width>32</width>
+      <connects-to>shifter_i2</connects-to>
+      <width>5</width>
       <triggers/>
       <sets-opcode/>
     </port>
     <port name="in2">
-      <connects-to>shifter_i2</connects-to>
-      <width>5</width>
+      <connects-to>shifter_i1</connects-to>
+      <width>32</width>
     </port>
     <port name="out1">
       <connects-to>shifter_o1</connects-to>
@@ -554,8 +533,8 @@
     </port>
     <operation>
       <name>shl</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
+      <bind name="1">in2</bind>
+      <bind name="2">in1t</bind>
       <bind name="3">out1</bind>
       <pipeline>
         <reads name="1">
@@ -574,8 +553,8 @@
     </operation>
     <operation>
       <name>shr</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
+      <bind name="1">in2</bind>
+      <bind name="2">in1t</bind>
       <bind name="3">out1</bind>
       <pipeline>
         <reads name="1">
@@ -594,66 +573,8 @@
     </operation>
     <operation>
       <name>shru</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
-      <bind name="3">out1</bind>
-      <pipeline>
-        <reads name="1">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <reads name="2">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <writes name="3">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </writes>
-      </pipeline>
-    </operation>
-    <address-space/>
-  </function-unit>
-
-  <function-unit name="rotator">
-    <port name="in1t">
-      <connects-to>rotator_i1</connects-to>
-      <width>32</width>
-      <triggers/>
-      <sets-opcode/>
-    </port>
-    <port name="in2">
-      <connects-to>rotator_i2</connects-to>
-      <width>32</width>
-    </port>
-    <port name="out1">
-      <connects-to>rotator_o1</connects-to>
-      <width>32</width>
-    </port>
-    <operation>
-      <name>rotl</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
-      <bind name="3">out1</bind>
-      <pipeline>
-        <reads name="1">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <reads name="2">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <writes name="3">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </writes>
-      </pipeline>
-    </operation>
-    <operation>
-      <name>rotr</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
+      <bind name="1">in2</bind>
+      <bind name="2">in1t</bind>
       <bind name="3">out1</bind>
       <pipeline>
         <reads name="1">

--- a/tce/data/mach/minimal_with_stdout.adf
+++ b/tce/data/mach/minimal_with_stdout.adf
@@ -133,27 +133,6 @@
     </writes-to>
   </socket>
 
-  <socket name="rotator_i1">
-    <reads-from>
-      <bus>B1</bus>
-      <segment>seg1</segment>
-    </reads-from>
-  </socket>
-
-  <socket name="rotator_i2">
-    <reads-from>
-      <bus>B1</bus>
-      <segment>seg1</segment>
-    </reads-from>
-  </socket>
-
-  <socket name="rotator_o1">
-    <writes-to>
-      <bus>B1</bus>
-      <segment>seg1</segment>
-    </writes-to>
-  </socket>
-
   <socket name="RF_i1">
     <reads-from>
       <bus>B1</bus>
@@ -544,16 +523,36 @@
     <address-space/>
   </function-unit>
 
-  <function-unit name="shifter">
+  <function-unit name="out">
+    <port name="t">
+      <connects-to>io_in</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+    </port>
+    <operation>
+      <name>stdout</name>
+      <bind name="1">t</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <address-space/>
+  </function-unit>
+
+  <function-unit name="shl_shr_shru">
     <port name="in1t">
       <connects-to>shifter_i1</connects-to>
-      <width>32</width>
+      <width>5</width>
       <triggers/>
       <sets-opcode/>
     </port>
     <port name="in2">
       <connects-to>shifter_i2</connects-to>
-      <width>5</width>
+      <width>32</width>
     </port>
     <port name="out1">
       <connects-to>shifter_o1</connects-to>
@@ -561,8 +560,8 @@
     </port>
     <operation>
       <name>shl</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
+      <bind name="1">in2</bind>
+      <bind name="2">in1t</bind>
       <bind name="3">out1</bind>
       <pipeline>
         <reads name="1">
@@ -581,8 +580,8 @@
     </operation>
     <operation>
       <name>shr</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
+      <bind name="1">in2</bind>
+      <bind name="2">in1t</bind>
       <bind name="3">out1</bind>
       <pipeline>
         <reads name="1">
@@ -601,8 +600,8 @@
     </operation>
     <operation>
       <name>shru</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
+      <bind name="1">in2</bind>
+      <bind name="2">in1t</bind>
       <bind name="3">out1</bind>
       <pipeline>
         <reads name="1">
@@ -617,84 +616,6 @@
           <start-cycle>0</start-cycle>
           <cycles>1</cycles>
         </writes>
-      </pipeline>
-    </operation>
-    <address-space/>
-  </function-unit>
-
-  <function-unit name="rotator">
-    <port name="in1t">
-      <connects-to>rotator_i1</connects-to>
-      <width>32</width>
-      <triggers/>
-      <sets-opcode/>
-    </port>
-    <port name="in2">
-      <connects-to>rotator_i2</connects-to>
-      <width>32</width>
-    </port>
-    <port name="out1">
-      <connects-to>rotator_o1</connects-to>
-      <width>32</width>
-    </port>
-    <operation>
-      <name>rotl</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
-      <bind name="3">out1</bind>
-      <pipeline>
-        <reads name="1">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <reads name="2">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <writes name="3">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </writes>
-      </pipeline>
-    </operation>
-    <operation>
-      <name>rotr</name>
-      <bind name="1">in1t</bind>
-      <bind name="2">in2</bind>
-      <bind name="3">out1</bind>
-      <pipeline>
-        <reads name="1">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <reads name="2">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
-        <writes name="3">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </writes>
-      </pipeline>
-    </operation>
-    <address-space/>
-  </function-unit>
-
-  <function-unit name="out">
-    <port name="t">
-      <connects-to>io_in</connects-to>
-      <width>32</width>
-      <triggers/>
-      <sets-opcode/>
-    </port>
-    <operation>
-      <name>stdout</name>
-      <bind name="1">t</bind>
-      <pipeline>
-        <reads name="1">
-          <start-cycle>0</start-cycle>
-          <cycles>1</cycles>
-        </reads>
       </pipeline>
     </operation>
     <address-space/>

--- a/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
+++ b/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
@@ -269,7 +269,7 @@ ProcessorImplementationWindow::updateRFList(const std::string& rfName, int index
     string hdb;
     int id = 0;
     try {
-        hdb = rfImpl.hdbFile();
+        hdb = Environment::shortHDBPath(rfImpl.hdbFile());
         id = rfImpl.id();
     } catch (FileNotFound& e) {
         hdb = "Warning: " + e.errorMessage();
@@ -313,7 +313,7 @@ ProcessorImplementationWindow::updateImplementationLists() {
             string hdb;
             int id = 0;
             try {
-                hdb = fuImpl.hdbFile();
+                hdb = Environment::shortHDBPath(fuImpl.hdbFile());
                 id = fuImpl.id();
             } catch (FileNotFound& e) {
                 hdb = "Warning: " + e.errorMessage();
@@ -338,7 +338,7 @@ ProcessorImplementationWindow::updateImplementationLists() {
             string hdb;
             int id = 0;
             try {
-                hdb = rfImpl.hdbFile();
+                hdb = Environment::shortHDBPath(rfImpl.hdbFile());
                 id = rfImpl.id();
             } catch (FileNotFound& e) {
                 hdb = "Warning: " + e.errorMessage();
@@ -362,7 +362,7 @@ ProcessorImplementationWindow::updateImplementationLists() {
             string hdb;
             int id = 0;
             try {
-                hdb = iuImpl.hdbFile();
+                hdb = Environment::shortHDBPath(iuImpl.hdbFile());
                 id = iuImpl.id();
             } catch (FileNotFound& e) {
                 hdb = "Warning: " + e.errorMessage();
@@ -491,7 +491,7 @@ void ProcessorImplementationWindow::updateFUList(const std::string& fuName, int 
     string hdb;
     int id = 0;
     try {
-        hdb = fuImpl.hdbFile();
+        hdb = Environment::shortHDBPath(fuImpl.hdbFile());
         id = fuImpl.id();
     } catch (FileNotFound& e) {
         hdb = "Warning: " + e.errorMessage();

--- a/tce/src/tools/Environment.cc
+++ b/tce/src/tools/Environment.cc
@@ -704,6 +704,22 @@ Environment::hdbPaths(bool libraryPathsOnly) {
     return paths;
 }
 
+std::string
+Environment::shortHDBPath(std::string hdbPath) {
+    if (StringTools::startsWith(hdbPath, TCE_SRC_ROOT)) {
+        int rootPathLength = string(TCE_SRC_ROOT).length();
+        hdbPath = "<source tree>" + hdbPath.substr(rootPathLength);
+    } else if (StringTools::startsWith(hdbPath,
+                                        Application::installationDir())) {
+        int installDirLength = Application::installationDir().length();
+        hdbPath = "<install directory>" + hdbPath.substr(installDirLength);
+    } else if (StringTools::startsWith(hdbPath,
+               FileSystem::currentWorkingDir())) {
+        int cwdLength = FileSystem::currentWorkingDir().length();
+        hdbPath = "." + hdbPath.substr(cwdLength);
+    }
+    return hdbPath;
+}
 
 /**
  * Returns the paths in which VHDL files are searched for.

--- a/tce/src/tools/Environment.cc
+++ b/tce/src/tools/Environment.cc
@@ -706,17 +706,19 @@ Environment::hdbPaths(bool libraryPathsOnly) {
 
 std::string
 Environment::shortHDBPath(std::string hdbPath) {
-    if (StringTools::startsWith(hdbPath, TCE_SRC_ROOT)) {
-        int rootPathLength = string(TCE_SRC_ROOT).length();
-        hdbPath = "<source tree>" + hdbPath.substr(rootPathLength);
-    } else if (StringTools::startsWith(hdbPath,
-                                        Application::installationDir())) {
-        int installDirLength = Application::installationDir().length();
-        hdbPath = "<install directory>" + hdbPath.substr(installDirLength);
-    } else if (StringTools::startsWith(hdbPath,
-               FileSystem::currentWorkingDir())) {
-        int cwdLength = FileSystem::currentWorkingDir().length();
-        hdbPath = "." + hdbPath.substr(cwdLength);
+    string sourceRoot = string(TCE_SRC_ROOT) + DS;
+    string installRoot = Application::installationDir() + DS;
+    string cwd = FileSystem::currentWorkingDir() + DS;
+
+    if (StringTools::startsWith(hdbPath, sourceRoot)) {
+        int rootPathLength = sourceRoot.length();
+        hdbPath = "<source tree>" + DS + hdbPath.substr(rootPathLength);
+    } else if (StringTools::startsWith(hdbPath, installRoot)) {
+        int installDirLength = installRoot.length();
+        hdbPath = "<install directory>" + DS + hdbPath.substr(installDirLength);
+    } else if (StringTools::startsWith(hdbPath, cwd)) {
+        int cwdLength = cwd.length();
+        hdbPath = "." + DS + hdbPath.substr(cwdLength);
     }
     return hdbPath;
 }

--- a/tce/src/tools/Environment.hh
+++ b/tce/src/tools/Environment.hh
@@ -77,6 +77,7 @@ public:
     static std::vector<std::string> hwModulePaths();
     static std::vector<std::string> hdbPaths(
             bool libraryPathsOnly = false);
+    static std::string shortHDBPath(std::string hdbPath);
     static std::vector<std::string> vhdlPaths(const std::string& hdbPath);
     static std::vector<std::string> decompressorPaths(
             bool libraryPathsOnly = false);

--- a/tce/src/tools/StringTools.cc
+++ b/tce/src/tools/StringTools.cc
@@ -133,6 +133,22 @@ StringTools::endsWith(
         searchString;
 }
 
+/**
+ * Checks whether a string starts with the given search string.
+ *
+ * @param source The investigated string.
+ * @param searchString The string to search from the start.
+ * @return True, if source starts with searchString.
+ */
+bool
+StringTools::startsWith(
+    const std::string& source,
+    const std::string& searchString) {
+
+    return source.size() >= searchString.size() &&
+        source.substr(0, searchString.size()) == searchString;
+}
+
 
 /**
  * Converts a string to upper case letters.

--- a/tce/src/tools/StringTools.hh
+++ b/tce/src/tools/StringTools.hh
@@ -55,6 +55,9 @@ public:
     static bool endsWith(
         const std::string& source,
         const std::string& searchString);
+    static bool startsWith(
+        const std::string& source,
+        const std::string& searchString);
 
     static std::string stringToUpper(const std::string& source);
     static std::string stringToLower(const std::string& source);


### PR DESCRIPTION
- Edit `minimal.adf` and `minimal_with_stdout.adf` so that their function units can be found in the main HDB (Issue #82)
- Shorten the HDB paths in implementation selection (Issue #80). Paths will now be prefixed with `<source tree>/`, `<install directory>/`, or `./` depending on their location