### PR TITLE
costdb test fixed + suppress a few compiler warnings

### DIFF
--- a/tce/src/applibs/LLVMBackend/TDGen.cc
+++ b/tce/src/applibs/LLVMBackend/TDGen.cc
@@ -343,7 +343,6 @@ TDGen::analyzeRegisterFileClasses() {
                 if (lane < 8 && lane > highestLaneBool_) {
                     highestLaneBool_ = lane;
                 }
-                //suppress fallthrough warning
                 /* fall through */
             case 32:
                 if (lane < 8 && lane > highestLaneInt_) {
@@ -3008,13 +3007,11 @@ TDGen::operandToString(
             if (operand.type() == Operand::RAW_DATA) {
                 return "R32FPRegs:$op" + Conversion::toString(idx);
             }
-            //Fall through to default
             /* fall through */
         case 'h':
             if (operand.type() == Operand::RAW_DATA) {
                 return "R32HFPRegs:$op" + Conversion::toString(idx);
             }
-            //Fall through to default
             /* fall through */
         default:
             std::string msg = 

--- a/tce/src/applibs/LLVMBackend/TDGen.cc
+++ b/tce/src/applibs/LLVMBackend/TDGen.cc
@@ -343,6 +343,8 @@ TDGen::analyzeRegisterFileClasses() {
                 if (lane < 8 && lane > highestLaneBool_) {
                     highestLaneBool_ = lane;
                 }
+                //suppress fallthrough warning
+                /* fall through */
             case 32:
                 if (lane < 8 && lane > highestLaneInt_) {
                     highestLaneInt_ = lane;
@@ -3006,10 +3008,14 @@ TDGen::operandToString(
             if (operand.type() == Operand::RAW_DATA) {
                 return "R32FPRegs:$op" + Conversion::toString(idx);
             }
+            //Fall through to default
+            /* fall through */
         case 'h':
             if (operand.type() == Operand::RAW_DATA) {
                 return "R32HFPRegs:$op" + Conversion::toString(idx);
             }
+            //Fall through to default
+            /* fall through */
         default:
             std::string msg = 
                 "invalid operation type for integer operand:";

--- a/tce/src/applibs/Scheduler/Algorithms/CopyingDelaySlotFiller.cc
+++ b/tce/src/applibs/Scheduler/Algorithms/CopyingDelaySlotFiller.cc
@@ -73,6 +73,8 @@ using std::vector;
 using namespace TTAProgram;
 using namespace TTAMachine;
 
+IGNORE_COMPILER_WARNING("-Wstrict-overflow")
+
 /**
  * Fill delay slots of given BB.
  *

--- a/tce/src/applibs/costdb/CostDatabaseRegistry.cc
+++ b/tce/src/applibs/costdb/CostDatabaseRegistry.cc
@@ -48,10 +48,7 @@ CostDatabaseRegistry::CostDatabaseRegistry() {
  */
 CostDatabaseRegistry::~CostDatabaseRegistry() {
     AssocTools::deleteAllValues(registry_);
-    if (instance_ != NULL) {
-        delete instance_;
-        instance_ = NULL;
-    }
+    instance_ = NULL;
 }
 
 /**

--- a/tce/src/base/tpef/TPEFSymbolSectionReader.cc
+++ b/tce/src/base/tpef/TPEFSymbolSectionReader.cc
@@ -26,7 +26,7 @@
  *
  * Definition of TPEFSymbolSectionReader class.
  *
- * @author Mikael Lepistö 2003 (tmlepist-no.spam-cs.tut.fi)
+ * @author Mikael LepistÃ¶ 2003 (tmlepist-no.spam-cs.tut.fi)
  *
  * @note rating: yellow
  */
@@ -217,7 +217,6 @@ TPEFSymbolSectionReader::createSymbol(
 
     case SymbolElement::STT_PROCEDURE:
         elem = new ProcedSymElement();
-        //Tell compiler that fallthrough is to be expected(suppresses a warning)
         /* fall through */
 
     case SymbolElement::STT_CODE:

--- a/tce/src/base/tpef/TPEFSymbolSectionReader.cc
+++ b/tce/src/base/tpef/TPEFSymbolSectionReader.cc
@@ -217,6 +217,8 @@ TPEFSymbolSectionReader::createSymbol(
 
     case SymbolElement::STT_PROCEDURE:
         elem = new ProcedSymElement();
+        //Tell compiler that fallthrough is to be expected(suppresses a warning)
+        /* fall through */
 
     case SymbolElement::STT_CODE:
         if (elem == NULL) {

--- a/tce/test/applibs/costdb/CostDBExactMatchTest/CostDBExactMatchTest.hh
+++ b/tce/test/applibs/costdb/CostDBExactMatchTest/CostDBExactMatchTest.hh
@@ -119,6 +119,7 @@ CostDBExactMatchTest::setUp() {
  */
 void CostDBExactMatchTest::tearDown() {
     mbus_property->destroy();
+    delete costDatabaseRegistry_;
 }
 
 


### PR DESCRIPTION
Costdb test now deletes the costdatabaseregistry properly.
Suppressed fallthrough warning with /* fall through */. Also suppressed a single -wstrict-overflow warning, where overflow shouldn't happen.