### PR TITLE
[tcecc] performance improvements

### DIFF
--- a/tce/src/applibs/PIG/AsciiImageWriter.cc
+++ b/tce/src/applibs/PIG/AsciiImageWriter.cc
@@ -197,3 +197,8 @@ AsciiImageWriter::writeHexSequence(
 
     nextBitIndex_ += length;
 }
+    }
+
+    nextBitIndex_ += length;
+}
+

--- a/tce/src/applibs/PIG/AsciiImageWriter.hh
+++ b/tce/src/applibs/PIG/AsciiImageWriter.hh
@@ -60,8 +60,6 @@ protected:
         std::ostream& stream, int length, bool padEnd = false) const;
 
     void
-    writeHexSequence(std::ostream& stream, int length, bool padEnd = false) const
-        throw (OutOfRange);
 
 private:
     /// The bits to be written.

--- a/tce/src/applibs/PIG/AsciiImageWriter.hh
+++ b/tce/src/applibs/PIG/AsciiImageWriter.hh
@@ -59,6 +59,10 @@ protected:
     void writeHexSequence(
         std::ostream& stream, int length, bool padEnd = false) const;
 
+    void
+    writeHexSequence(std::ostream& stream, int length, bool padEnd = false) const
+        throw (OutOfRange);
+
 private:
     /// The bits to be written.
     const BitVector& bits_;

--- a/tce/src/applibs/PIG/ProgramImageGenerator.cc
+++ b/tce/src/applibs/PIG/ProgramImageGenerator.cc
@@ -365,7 +365,7 @@ ProgramImageGenerator::generateProgramImage(
     } else if (format == COE) {
         writer = new CoeImageWriter(*programBits, mau);
     } else if (format == HEX) {
-        writer = new HexImageWriter(*programBits, mau);
+    	writer = new HexImageWriter(*programBits, mau);
     } else {
         assert(false);
     }

--- a/tce/src/bintools/Compiler/tcecc.in
+++ b/tce/src/bintools/Compiler/tcecc.in
@@ -317,7 +317,7 @@ def processInputFiles(inFiles, tmpDir, options, tceopsDir=None):
 
                         command = ("clang %s %s " + \
                                        "-emit-llvm -O3 "\
-                                       "-fno-inline -c -I" + tmpDir +\
+                                       "-c -I" + tmpDir +\
                                        " " + input + " " + extra_opts + \
                                        " %s `pkg-config pocl --cflags`" + \
                                        " -o " + output) % \
@@ -387,7 +387,7 @@ def processInputFiles(inFiles, tmpDir, options, tceopsDir=None):
 
                     command = ("clang %s %s %s -emit-llvm " +\
                                     "-O%d "\
-                                    "-fno-inline -c -I" + tmpDir + \
+                                    "-c -I" + tmpDir + \
                                     " " + compileFlags + " " + input_file + " -o " +\
                                     outFileName + ".tobelowered1;") % \
                                     (tripleOption, triple, extra_opts, options.frontend_optlevel)

--- a/tce/src/bintools/Compiler/tcecc.in
+++ b/tce/src/bintools/Compiler/tcecc.in
@@ -385,6 +385,9 @@ def processInputFiles(inFiles, tmpDir, options, tceopsDir=None):
                     if options.soft_float:
                         extra_opts += " -ffp-contract=off"
 
+                    if options.cxxstd:
+                        extra_opts += " --std=%s" % options.cxxstd
+
                     command = ("clang %s %s %s -emit-llvm " +\
                                     "-O%d "\
                                     "-c -I" + tmpDir + \
@@ -1093,6 +1096,11 @@ p.add_option('--init-sp',
              type="long", action="store", metavar='value',
              dest='init_sp', default=None,
              help="Set the initial stack pointer of the program to the given value.")
+
+p.add_option('--std',
+             type="string", action="store", metavar='value',
+             dest='cxxstd', default='c++11',
+             help="C++ language standard to compile for.")
 
 p.add_option('--little-endian',
              action="store_true", dest='little_endian', default=False,


### PR DESCRIPTION
Changes for tcecc for a optimized compile result:

- removed "-fno-inline" as default option to clang as this might lead to worse compile results
- added "--std=" in order to specity the C++ language standard to compile for
