### PR TITLE
Expand sign-ext loads when they are not legal

### DIFF
--- a/tce/src/applibs/LLVMBackend/TCETargetMachine.hh
+++ b/tce/src/applibs/LLVMBackend/TCETargetMachine.hh
@@ -249,8 +249,18 @@ plugin_(plugin) {
             return plugin_->has8bitLoads();
         }
 
+        bool
+        has8bitSELoads() const {
+            return plugin_->has8bitSELoads();
+        }
+
         bool has16bitLoads() const {
             return plugin_->has16bitLoads();
+        }
+
+        bool
+        has16bitSELoads() const {
+            return plugin_->has16bitSELoads();
         }
 
         const std::set<

--- a/tce/src/applibs/LLVMBackend/TCETargetMachinePlugin.hh
+++ b/tce/src/applibs/LLVMBackend/TCETargetMachinePlugin.hh
@@ -148,7 +148,9 @@ namespace llvm {
        virtual bool hasSHRU() const = 0;
 
        virtual bool has8bitLoads() const = 0;
+       virtual bool has8bitSELoads() const = 0;
        virtual bool has16bitLoads() const = 0;
+       virtual bool has16bitSELoads() const = 0;
 
        virtual int maxVectorSize() const = 0;
        /// Plugin needs target machine for TragetLowering generation

--- a/tce/src/applibs/LLVMBackend/TDGen.cc
+++ b/tce/src/applibs/LLVMBackend/TDGen.cc
@@ -1377,7 +1377,9 @@ TDGen::writeBackendCode(std::ostream& o) {
     bool hasSHRU = false;
     bool hasSHL = false;
     bool has8bitLoads = false;
+    bool has8bitSELoads = false;
     bool has16bitLoads = false;
+    bool has16bitSELoads = false;
 
     const TTAMachine::Machine::FunctionUnitNavigator fuNav =
         mach_.functionUnitNavigator();
@@ -1403,15 +1405,23 @@ TDGen::writeBackendCode(std::ostream& o) {
             if (opName == "sqrtf") hasSQRTF = true;
 
             if (littleEndian_) {
-                if (opName == "ld16" || opName == "ldu16") {
+                if (opName == "ld16") {
+                    has16bitSELoads = true;
+                } else if (opName == "ldu16") {
                     has16bitLoads = true;
-                } else if(opName == "ld8" || opName == "ldu8") {
+                } else if (opName == "ld8") {
+                    has8bitSELoads = true;
+                } else if (opName == "ldu8") {
                     has8bitLoads = true;
                 }
             } else {
-                if (opName == "ldh" || opName == "ldhu") {
+                if (opName == "ldh") {
+                    has16bitSELoads = true;
+                } else if (opName == "ldhu") {
                     has16bitLoads = true;
-                } else if (opName == "ldq" || opName == "ldqu") {
+                } else if (opName == "ldq") {
+                    has8bitSELoads = true;
+                } else if (opName == "ldqu") {
                     has8bitLoads = true;
                 }
            }
@@ -1447,8 +1457,12 @@ TDGen::writeBackendCode(std::ostream& o) {
       << hasSHRU << ";}" << std::endl
       << "bool GeneratedTCEPlugin::has8bitLoads() const { return "
       << has8bitLoads << ";}" << std::endl
+      << "bool GeneratedTCEPlugin::has8bitSELoads() const { return "
+      << has8bitSELoads << ";}" << std::endl
       << "bool GeneratedTCEPlugin::has16bitLoads() const { return "
       << has16bitLoads << ";}" << std::endl
+      << "bool GeneratedTCEPlugin::has16bitSELoads() const { return "
+      << has16bitSELoads << ";}" << std::endl
 
       << "int GeneratedTCEPlugin::maxVectorSize() const { return "
       << maxVectorSize_ << "; }" << std::endl;

--- a/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.cc
@@ -702,14 +702,17 @@ TCETargetLowering::TCETargetLowering(
                       << "lots of 8-bit loads." << std::endl;
         }
         setLoadExtAction(ISD::EXTLOAD, MVT::i32, MVT::i8, Custom);
-        setLoadExtAction(ISD::SEXTLOAD, MVT::i32, MVT::i8, Custom);
         setLoadExtAction(ISD::ZEXTLOAD, MVT::i32, MVT::i8, Custom);
         setOperationAction(ISD::LOAD, MVT::i8, Custom);
         setOperationAction(ISD::LOAD, MVT::i1, Custom);
 
         setLoadExtAction(ISD::EXTLOAD, MVT::i32, MVT::i1, Custom);
-        setLoadExtAction(ISD::SEXTLOAD, MVT::i32, MVT::i1, Custom);
         setLoadExtAction(ISD::ZEXTLOAD, MVT::i32, MVT::i1, Custom);
+    }
+    // Expand i8/i1 sextloads if there is no native SELoad in the target
+    if (!tm_.has8bitSELoads()) {
+        setLoadExtAction(ISD::SEXTLOAD, MVT::i32, MVT::i8, Expand);
+        setLoadExtAction(ISD::SEXTLOAD, MVT::i32, MVT::i1, Expand);
     }
 
     if (!tm_.has16bitLoads()) {
@@ -720,9 +723,13 @@ TCETargetLowering::TCETargetLowering(
                       << "lots of 16-bit loads." << std::endl;
         }
         setLoadExtAction(ISD::EXTLOAD, MVT::i32, MVT::i16, Custom);
-        setLoadExtAction(ISD::SEXTLOAD, MVT::i32, MVT::i16, Custom);
         setLoadExtAction(ISD::ZEXTLOAD, MVT::i32, MVT::i16, Custom);
         setOperationAction(ISD::LOAD, MVT::i16, Custom);
+    }
+
+    // Expand i16 sextloads if there is no native SELoad in the target
+    if (!tm_.has16bitSELoads()) {
+        setLoadExtAction(ISD::SEXTLOAD, MVT::i32, MVT::i16, Expand);
     }
 
     setOperationAction(ISD::ADDE, MVT::i32, Expand);

--- a/tce/src/applibs/LLVMBackend/plugin/TCETargetMachinePlugin.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/TCETargetMachinePlugin.cc
@@ -117,7 +117,9 @@ public:
     virtual bool hasSHL() const override;
     virtual bool hasSHRU() const override;
     virtual bool has8bitLoads() const override;
+    virtual bool has8bitSELoads() const override;
     virtual bool has16bitLoads() const override;
+    virtual bool has16bitSELoads() const override;
 
     virtual int maxVectorSize() const;
 


### PR DESCRIPTION
If the target do not have native loads, expanding them
helps the ISL for custom operations (eg: add_se: se + add)