### PR TITLE
fix a typo

### DIFF
--- a/tce/opset/base/Makefile.am
+++ b/tce/opset/base/Makefile.am
@@ -91,7 +91,7 @@ all-local: ${pkglib_LTLIBRARIES}
 install-exec-hook:
 	cd $(DESTDIR)/${pkglibdir} ; ln -sf base.so base.opb ; \
 ln -sf avalon.so avalon.opb ; ln -sf simple_io.so simple_io.opb ; \
-ln -sf double.so double.obp
+ln -sf double.so double.opb
 
 clean-local:
 	rm -f ./base.opb


### PR DESCRIPTION
```
root@502f16f841e9:/# /home/TCE_100/bin/tce-config --version
1.22-pre-r4053
```

Running ttasim via pocl results in:

```
This may cause program to hang if operation in this module is attempted to be simulated.
Warning: Found operation module specification file /home/TCE_100/share/tce/opset/base/double.opp and operation behavious source file /home/TCE_100/share/tce/opset/base/double.cc without compiled behaviour implementation file /home/TCE_100/share/tce/opset/base/double.opb.

Tried to compile behaviour impelementaton file, but the compilation failed to error: 
/usr/bin/ld: cannot find -lwx_gtk2u_xrc-3.0

/usr/bin/ld: cannot find -lwx_gtk2u_html-3.0

/usr/bin/ld: cannot find -lwx_gtk2u_qa-3.0

/usr/bin/ld: cannot find -lwx_gtk2u_adv-3.0

/usr/bin/ld: cannot find -lwx_gtk2u_core-3.0
```
There is no double.opb file:

```
root@502f16f841e9:/home/TCE_100# ls -l /home/TCE_100/share/tce/opset/base/double.opb
ls: cannot access '/home/TCE_100/share/tce/opset/base/double.opb': No such file or directory
```

there is however double.**obp** file:

```
root@502f16f841e9:/home/TCE_100# ls -l /home/TCE_100/share/tce/opset/base/double.obp
lrwxrwxrwx 1 root root 9 Aug  4 18:13 /home/TCE_100/share/tce/opset/base/double.obp -> double.so
```

.... seems like a simple typo.