### PR TITLE
Python 3 support

### DIFF
--- a/tce/Python-bindings/scripts/cfgTest.py
+++ b/tce/Python-bindings/scripts/cfgTest.py
@@ -1,18 +1,18 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright (c) 2002-2009 Tampere University.
 #
 # This file is part of TTA-Based Codesign Environment (TCE).
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
 # deal in the Software without restriction, including without limitation the
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,7 +23,7 @@
 import TCE.base.program as prog
 import TCE.base.mach as mach
 import TCE.applibs.Scheduler.ProgramRepresentations.ControlFlowGraph as cfg
-import TCE.base.osal as osal 
+import TCE.base.osal as osal
 import sys
 
 def printOut(pr):
@@ -39,34 +39,34 @@ def printOut(pr):
         immediateSum = immediateSum + stats.immediateCount()
         instructionSum = instructionSum + stats.instructionCount()
         bypassSum = bypassSum + stats.bypassedCount()
-        blocks = blocks + stats.normalBBCount()        
-    print "Program:"+sys.argv[1]
-    print "\tMoves:",moveSum  
-    print "\tImmediates:",immediateSum 
-    print "\tInstructions:",instructionSum 
-    print "\tBasicBlocks:",blocks
-    print "\tProcedures:",pr.procedureCount()
-    print "\tMovesPerCycle:",1.0*moveSum/instructionSum 
+        blocks = blocks + stats.normalBBCount()
+    print("Program:"+sys.argv[1])
+    print("\tMoves:",moveSum)
+    print("\tImmediates:",immediateSum)
+    print("\tInstructions:",instructionSum)
+    print("\tBasicBlocks:",blocks)
+    print("\tProcedures:",pr.procedureCount())
+    print("\tMovesPerCycle:",1.0*moveSum/instructionSum)
 
-if __name__ == "__main__":        
+if __name__ == "__main__":
     if len(sys.argv) < 2 or len(sys.argv) > 4:
-        print "Usage: python cfgTest.py tpef [adf] ['sum']"
+        print("Usage: python cfgTest.py tpef [adf] ['sum']")
     if len(sys.argv) == 4 and sys.argv[3] == "sum":
             um = mach.UniversalMachine()
             machine = mach.Machine.loadFromADF(sys.argv[2])
             pr = prog.Program.loadFromTPEF(sys.argv[1], machine, um)
             printOut(pr)
-    else: 
+    else:
         if len(sys.argv) == 3:
             if (sys.argv[2] != "sum") :
                 um = mach.UniversalMachine()
                 machine = mach.Machine.loadFromADF(sys.argv[2])
                 pr = prog.Program.loadFromTPEF(sys.argv[1], machine, um)
-                print "Count of procedures in '", sys.argv[1], "' is " 
-                print pr.procedureCount()
+                print("Count of procedures in '", sys.argv[1], "' is ")
+                print(pr.procedureCount())
                 for i in range(pr.procedureCount()):
                     cf = cfg.ControlFlowGraph(pr.procedure(i))
-                    print cf.printStatistics()
+                    print(cf.printStatistics())
             else :
                 um = mach.UniversalMachine()
                 pr = prog.Program.loadFromTPEF(sys.argv[1], um)
@@ -75,10 +75,10 @@ if __name__ == "__main__":
             if len(sys.argv) == 2:
                 um = mach.UniversalMachine()
                 pr = prog.Program.loadFromTPEF(sys.argv[1], um)
-                print "Count of procedures in '", sys.argv[1], "' is " 
-                print pr.procedureCount()
+                print("Count of procedures in '", sys.argv[1], "' is ")
+                print(pr.procedureCount())
                 for i in range(pr.procedureCount()):
                     cf = cfg.ControlFlowGraph(pr.procedure(i))
-                    print cf.printStatistics()     
+                    print(cf.printStatistics())
             else:
-                print "Usage: python cfgTest.py tpef [adf] ['sum']"   
+                print("Usage: python cfgTest.py tpef [adf] ['sum']")

--- a/tce/Python-bindings/src/setup.py.in
+++ b/tce/Python-bindings/src/setup.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #
 # Python distutils file for building and installing the
@@ -137,13 +137,13 @@ setup(name='TCE Python bindings',
                              define_macros=TCE_define_macros,
                              include_dirs=TCE_includes,
                              library_dirs=TCE_library_dirs,
-                             libraries=TCE_libraries),                             
+                             libraries=TCE_libraries),
                    Extension('TCE.applibs.Scheduler.ProgramRepresentations.DataDependenceGraph',
                              list_cpps('DataDependenceGraph'),
                              define_macros=TCE_define_macros,
                              include_dirs=TCE_includes,
                              library_dirs=TCE_library_dirs,
-                             libraries=TCE_libraries),                             
+                             libraries=TCE_libraries),
                    Extension('TCE.applibs.Scheduler.SchedulerModules',
 
                              # This is a temporary solution to get the two .cpp files included
@@ -160,14 +160,12 @@ setup(name='TCE Python bindings',
                                               '%s/scheduler/passes/BasicBlockScheduler/CopyingDSFillerModule.so'
                                               % project_root,
                                               ],
-                             libraries=TCE_libraries),                             
+                             libraries=TCE_libraries),
                    Extension('TCE.applibs.Scheduler.Algorithms',
                              list_cpps('Algorithms'),
                              define_macros=TCE_define_macros,
                              include_dirs=TCE_includes,
                              library_dirs=TCE_library_dirs,
-                             libraries=TCE_libraries),                             
+                             libraries=TCE_libraries),
                    ]
 )
-      
-     

--- a/tce/configure.ac
+++ b/tce/configure.ac
@@ -383,12 +383,12 @@ CXXFLAGS="$CXXFLAGS -ftest-coverage -fprofile-arcs"
 
 ####################################################################
 #
-# Python 2.x for the tcecc compiler driver script.
+# Python 3.x for the tcecc compiler driver script.
 #
 ####################################################################
 AC_MSG_CHECKING(for python binary)
 AC_MSG_RESULT([])
-for python in python2.9 python2.8 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+for python in python3; do
 AC_CHECK_PROGS(PYTHON_BIN, [$python])
 ax_python_bin=$PYTHON_BIN
 if test x$ax_python_bin != x; then
@@ -397,18 +397,18 @@ fi
 done
 
 if test x$PYTHON_BIN == x; then
-   AC_MSG_ERROR([Python 2.x not found.])
+   AC_MSG_ERROR([Python 3.x not found.])
 fi
 
 PYTHON_VERSION=`$PYTHON_BIN --version 2>&1 | cut -d ' ' -f 2 | cut -d '.' -f 1,2`
 
 case "$PYTHON_VERSION" in
-     2.*)
-     AC_DEFINE([PYTHON_2], [], "Using Python 2.x")
+     3.*)
+     AC_DEFINE([PYTHON_2], [], "Using Python 3.x")
      ;;
      *)
      AC_MSG_NOTICE([Python version: $PYTHON_VERSION])
-     AC_MSG_ERROR([Python 2.x not found.])
+     AC_MSG_ERROR([Python 3.x not found.])
 esac
 
 ####################################################################

--- a/tce/scheduler/testbench/scheduler_tester.py
+++ b/tce/scheduler/testbench/scheduler_tester.py
@@ -1,20 +1,20 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# 
+#
 # Copyright (c) 2002-2010 Tampere University.
 #
 # This file is part of TTA-Based Codesign Environment (TCE).
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
 # deal in the Software without restriction, including without limitation the
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,13 +26,14 @@
 # @author 2006-2010 Pekka Jääskeläinen
 #
 
-import getopt, sys, os, glob, __builtin__, subprocess, time, signal, csv, tempfile, math
+import getopt, sys, os, glob, builtins, subprocess, time, signal, csv, tempfile, math
 
 # This shadows builtin open with the nasty os.open.
 from os import *
 from subprocess import *
 from difflib import unified_diff
 from pprint import pformat
+import traceback
 
 
 # General settings.
@@ -44,8 +45,8 @@ schedulingTimeoutSec = 100*60
 simulationTimeoutSec = 120*60
 
 def usage():
-    print "Usage: scheduler_tester.py [options]"
-    print """
+    print("Usage: scheduler_tester.py [options]")
+    print("""
 Options:
   -a <ADF> Override architecture with which to run tests
   -b <list of test case directories to include> The matching is done from the
@@ -62,7 +63,7 @@ Options:
      generated_seq_program otherwise.
      e.g scheduler_tester.py -x -g \"-O3\"
   -h This help text.
-  -i <comma separated list of stats>. Print more statistics for each run. 
+  -i <comma separated list of stats>. Print more statistics for each run.
      Stats available:
      c=cycle count, rr=register reads, rw=register writes, oc=operation count,
      opc=ops/cycle, and 'all' which includes all stats. Example: 'rr,rw'
@@ -78,7 +79,7 @@ Options:
   -q Use compiled simulation (slow initialization, fast simulation, basic
      block simulation granularity).
   -r Regression test mode. Do not output anything unless there's an error, in
-     which case output as normal.  
+     which case output as normal.
   -s Stop testing after the first FAILED test encountered.
   -t Update top results (only the improved cycle counts) if all tests passed.
   -T Update top results (even the worsened ones) if all tests passed, thus
@@ -99,16 +100,16 @@ Options:
   disabled.txt         If test is disabled for specific reason this file can
                        be created with reason message.
   program.bc           LLVM byte code file is test should be ran when
-                       -x switch *is* set.		       
+                       -x switch *is* set.
   sequential_program   Universal tpef binary, if wanted that test is ran
                        when -x switch *is not* set.
   simulate.ttasim      Lines to feed into ttasim to simulate and dump
                        verification output. If exists, no run command is given
-    	               by the tester but only the commands from this file
+                       by the tester but only the commands from this file
                        are executed.
-  extraCompileFlags    Adds contents of this file as extra parameters to tcecc.               
+  extraCompileFlags    Adds contents of this file as extra parameters to tcecc.
   ----------------------------------------------------------------------------
-"""
+""")
 
 # Location of the scheduler and simulator programs relative to the location
 # of this script.
@@ -127,7 +128,7 @@ tceccExe = os.path.normpath(rootDir + "/" + tceccExe)
 testRootDir = "."
 
 backendCacheDir = None
-def get_backend_cache_dir():    
+def get_backend_cache_dir():
     """Returns the location of the backend plugin directory.
 
     Creates a new temporary directory, if there's not one already."""
@@ -147,7 +148,7 @@ def get_backend_cache_dir():
 # Find the ADF and Operations directory in the same directory
 # the script is at.
 fileListing = glob.glob(ADFDir + "/*.adf")
-allArchitectures = map(os.path.basename, fileListing)
+allArchitectures = list(map(os.path.basename, fileListing))
 
 stopTestingAfterFailingTest = False
 csvFormat = False
@@ -182,8 +183,8 @@ cmdLineArchitectures = []
 failureFound = False
 
 if len(allArchitectures) == 0:
-    print "No architecture files found in " + ADFDir
-    sys.exit(3)    
+    print("No architecture files found in " + ADFDir)
+    sys.exit(3)
 
 def ParseCommandLine():
 
@@ -198,13 +199,13 @@ def ParseCommandLine():
 
     try:
         args_start = 1
-            
+
         opts, args = getopt.getopt(\
             sys.argv[args_start:], "g:a:b:shtTvVCopqrxw:dlLi:e:", ["help"])
 
-    except getopt.GetoptError, e:
+    except getopt.GetoptError as e:
         # print help information and exit:
-        print str(e)
+        print(str(e))
         sys.exit(1)
 
     for o, a in opts:
@@ -221,7 +222,7 @@ def ParseCommandLine():
             verboseOutput = True
         elif o == "-V":
             verboseOutput = True
-            veryVerboseOutput = True            
+            veryVerboseOutput = True
         elif o == "-C":
             csvFormat = True
         elif o == "-p":
@@ -233,7 +234,8 @@ def ParseCommandLine():
             # Write everything to a tmpfile and in case of an error only,
             # copy everything from that tmpfile to stdout at the end of
             # execution.
-            sys.stdout = tmpfile()
+            temp_file, path = tempfile.mkstemp(text=True)
+            sys.stdout = builtins.open(temp_file, mode='w+')
         elif o == "-a":
             for arch in a.split(','):
                 cmdLineArchitectures.append(arch)
@@ -271,9 +273,9 @@ def ParseCommandLine():
 
     def file_readable(filename):
         return access(filename, R_OK)
-               
+
     normalOutput = not latexTable and not csvFormat
-        
+
 def runWithTimeout(command, timeoutSecs, inputStream = ""):
     """
     Runs the given process until it exits or the given time out is reached.
@@ -282,20 +284,20 @@ def runWithTimeout(command, timeoutSecs, inputStream = ""):
     second gives the process' output from stdout as a string, third the stderr
     """
     global veryVerboseOutput
-    
+
     timePassed = 0.0
     increment = 0.01
-    
+
     stderrFD, errFile = tempfile.mkstemp()
     stdoutFD, outFile = tempfile.mkstemp()
 
     if veryVerboseOutput:
-        print "running: %s input-stream: %s" % (command,inputStream)
+        print("running: %s input-stream: %s" % (command,inputStream))
 
-    process =  Popen(command, shell=True, stdin=PIPE, stdout=stdoutFD, stderr=stderrFD, close_fds=False)
+    process = subprocess.Popen(command, shell=True, stdin=PIPE, stdout=stdoutFD, stderr=stderrFD, close_fds=False, text=True)
 
-    if process == None:
-        print "Could not create process"
+    if process is None:
+        print("Could not create process")
         sys.exit(1)
 
     try:
@@ -306,16 +308,16 @@ def runWithTimeout(command, timeoutSecs, inputStream = ""):
 
         while True:
             status = process.poll()
-            if status != None:
-                # Process terminated succesfully.            
+            if status is not None:
+                # Process terminated succesfully.
                 stdoutSize = os.lseek(stdoutFD, 0, 2)
                 stderrSize = os.lseek(stderrFD, 0, 2)
 
                 os.lseek(stdoutFD, 0, 0)
                 os.lseek(stderrFD, 0, 0)
 
-                stdoutContents = os.read(stdoutFD, stdoutSize)
-                stderrContents = os.read(stderrFD, stderrSize)
+                stdoutContents = os.read(stdoutFD, stdoutSize).decode('utf-8')
+                stderrContents = os.read(stderrFD, stderrSize).decode('utf-8')
 
                 os.close(stdoutFD)
                 os.remove(outFile)
@@ -323,7 +325,7 @@ def runWithTimeout(command, timeoutSecs, inputStream = ""):
                 os.remove(errFile)
 
                 return (True, stdoutContents, stderrContents)
-        
+
             if timePassed < timeoutSecs:
                 time.sleep(increment)
                 timePassed = timePassed + increment
@@ -336,21 +338,23 @@ def runWithTimeout(command, timeoutSecs, inputStream = ""):
                 os.lseek(stdoutFD, 0, 0)
                 os.lseek(stderrFD, 0, 0)
 
-                stdoutContents = os.read(stdoutFD, stdoutSize)
-                stderrContents = os.read(stderrFD, stderrSize)
+                stdoutContents = os.read(stdoutFD, stdoutSize).decode('utf-8')
+                stderrContents = os.read(stderrFD, stderrSize).decode('utf-8')
 
                 os.close(stdoutFD)
                 os.remove(outFile)
                 os.close(stderrFD)
                 os.remove(errFile)
-            
+
                 os.kill(process.pid, signal.SIGTSTP)
-            
+
                 return (False, stdoutContents, stderrContents)
     except KeyboardInterrupt:
         os.kill(process.pid, signal.SIGTSTP)
         raise
-    except:
+    except Exception:
+        print(traceback.format_exc(), file=sys.stderr)
+
         # if something threw exception (e.g. ctrl-c)
         os.kill(process.pid, signal.SIGTSTP)
 
@@ -362,8 +366,8 @@ def runWithTimeout(command, timeoutSecs, inputStream = ""):
             os.lseek(stdoutFD, 0, 0)
             os.lseek(stderrFD, 0, 0)
 
-            stdoutContents = os.read(stdoutFD, stdoutSize)
-            stderrContents = os.read(stderrFD, stderrSize)
+            stdoutContents = os.read(stdoutFD, stdoutSize).decode('utf-8')
+            stderrContents = os.read(stderrFD, stderrSize).decode('utf-8')
 
             os.close(stdoutFD)
             os.remove(outFile)
@@ -371,14 +375,14 @@ def runWithTimeout(command, timeoutSecs, inputStream = ""):
             os.remove(errFile)
         except:
             pass
-        
+
         return (False, stdoutContents, stderrContents)
 
 def callSilent(command):
     schedProc = Popen(command, shell=True, stdin=None, stdout=None, stderr=None, close_fds=True)
     schedProc.communicate()
     return schedProc.returncode
-        
+
 def tryRemove(filename):
     try:
         os.remove(filename)
@@ -388,10 +392,10 @@ def tryRemove(filename):
 class TestBenchException(RuntimeError):
     def __init__(self, msg):
         self.msg = msg
-        
+
     def getMsg(self):
         return self.msg
-    
+
 class TestRunResult:
     """Stores data of a single test run.
 
@@ -407,11 +411,11 @@ class SimulationStats:
         self.registerReads = 0
         self.registerWrites = 0
         self.operationExecutions = 0
-    
+
     def decodeStatString(self, stat):
         """
         Interprets a statistics string given in a list of '-i' switch.
-        
+
         Returns a tuple with first column a long name for statistic,
         second column a short name (can be equal to stat), and third
         column the value of the statistics.
@@ -432,9 +436,9 @@ class SimulationStats:
                 pass
             return ('operation per cycle', 'opc', '%.2f' % value)
         else:
-            print 'unknown statistics type:',stat
+            print('unknown statistics type:', stat)
             return (None, None, None)
-    
+
     def toLatexRow(self, statColumns, colWidth=16):
         """
         Generates a row of results in LaTeX table format according to the
@@ -462,14 +466,14 @@ class TestCase:
         if not access(self.directory + "/topresults.csv", R_OK):
             self.oldResults = None
             return
-        reader = csv.reader(__builtin__.open(self.directory + "/topresults.csv", "rb"))
+        reader = csv.reader(builtins.open(self.directory + "/topresults.csv", "rt"))
         self.oldResults = {}
         for row in reader:
             self.oldResults[row[0]] = row[1:]
-        
+
     def __init__(self, directory):
 
-        """Loads a new test case stored in the given directory."""        
+        """Loads a new test case stored in the given directory."""
 
         global cmdLineArchitectures
         global extraCompileFlags
@@ -483,24 +487,24 @@ class TestCase:
         else:
             self.title = directory
 
-        descriptionFile = __builtin__.open(directory + '/description.txt', 'r')
+        descriptionFile = builtins.open(directory + '/description.txt', 'r')
         self.description = descriptionFile.read().strip()
         descriptionFile.close()
 
         if os.access(directory + '/architectures.lst', R_OK):
-            archFile = __builtin__.open(directory + '/architectures.lst')
+            archFile = builtins.open(directory + '/architectures.lst')
             for line in archFile.read().splitlines():
                 arch = line.strip()
                 if arch != '':
                     self.architectures.append(arch)
             archFile.close()
         elif len(cmdLineArchitectures) > 0:
-            self.architectures = cmdLineArchitectures            
+            self.architectures = cmdLineArchitectures
         else:
             self.architectures = allArchitectures
 
         if os.access(directory + '/extraCompileFlags', R_OK):
-            flagsFile = __builtin__.open(directory + '/extraCompileFlags')
+            flagsFile = builtins.open(directory + '/extraCompileFlags')
             for line in flagsFile.read().splitlines():
                 param = line.strip()
                 if param != '':
@@ -509,15 +513,15 @@ class TestCase:
                     self.testExtraCompileFlags += ' ';
 
         self.improvedRuns = False
-        # Simulation results for each architecture (the verification data and the 
+        # Simulation results for each architecture (the verification data and the
         # cycle count).
-        self.results = {}      
+        self.results = {}
         # Simulation stats for each architecture.
-        self.stats = {}  
+        self.stats = {}
         self.loadOldResults()
         self.setupExecuted = False
         self.parallelPrograms = []
-        
+
         # If requested. stores the results for each architecture in LaTeX format
         self.latexResults = {}
         self.latexColumnCount = 0
@@ -539,7 +543,7 @@ class TestCase:
             os.symlink(operationDir, "src/data")
         except:
             pass
-        
+
         tryRemove("cyclecount")
         tryRemove("generated_seq_program")
         tryRemove("src/generated_seq_program")
@@ -555,7 +559,7 @@ class TestCase:
 
         if deleteOSALLink:
             tryRemove("data")
-            
+
         tryRemove("cyclecount")
         tryRemove("ttasim.out")
         tryRemove("generated_seq_program")
@@ -573,7 +577,7 @@ class TestCase:
         if not saveParallelPrograms:
             for tpef in self.parallelPrograms:
                 tryRemove(tpef)
-                
+
         if access("./cleanup.sh", X_OK):
             callSilent("./cleanup.sh")
 
@@ -587,19 +591,19 @@ class TestCase:
         else:
             sys.stdout.write("FAILED! " + reason)
             sys.stdout.write(" (!)\n")
-        
+
             if verboseOutput and len(verbose) > 0:
                 sys.stdout.write("[" + verbose + "]\n")
-            
+
         sys.stdout.flush()
         failureFound = True
 
     def verifySimulation(self):
         if access("correct_simulation_output", R_OK):
-            correctOutputFile = __builtin__.open("correct_simulation_output", "r")
+            correctOutputFile = builtins.open("correct_simulation_output", "r")
             correctOutput = correctOutputFile.read().strip().split("\n")
-            self.simStdOut = self.simStdOut.strip().split("\n")    
-	
+            self.simStdOut = self.simStdOut.strip().split("\n")
+
             if correctOutput != self.simStdOut:
                 # The outputs differ.
                 result = list(unified_diff(correctOutput, self.simStdOut))
@@ -616,7 +620,7 @@ class TestCase:
             if retcode != 0:
                 self.testFailed("verification with 'verify.sh' failed (retcode %d)" % retcode)
                 return False
-                     
+
         return True
 
     def schedule(self, archFilename, seqProgFileName, dstProgFileName):
@@ -635,14 +639,14 @@ class TestCase:
         schedulingCommand += " -o " + dstProgFileName + \
                              " -a " + archFilename + \
                              " " + seqProgFileName
-                
-                
+
+
         exitOk, stdoutContents, stderrContents = runWithTimeout(schedulingCommand, schedulingTimeoutSec)
 
         if not exitOk:
             self.testFailed("scheduling timeout")
             return False
-        
+
         errmsg = stderrContents
         status = not exitOk
 
@@ -650,7 +654,7 @@ class TestCase:
                not access(dstProgFileName, R_OK):
             self.testFailed("compilation error", errmsg)
             return False
-        
+
 
         if veryVerboseOutput and len(errmsg) > 0:
             sys.stdout.write("[" + errmsg + "]\n")
@@ -660,9 +664,9 @@ class TestCase:
     def simulate(self, archFilename, progFilename):
 
         global compiledSimulation
-        
+
         # Create the simulation script.
-        simulationScript = ""       
+        simulationScript = ""
 
         if not archFilename == "":
             simulationScript += "mach " + archFilename + "\n"
@@ -670,7 +674,7 @@ class TestCase:
         simulationScript = simulationScript + "prog " + progFilename + "\n"
 
         if access("simulate.ttasim", R_OK):
-            script = __builtin__.open("simulate.ttasim", "r")
+            script = builtins.open("simulate.ttasim", "r")
             simulationScript = simulationScript + script.read()
         else:
             simulationScript = simulationScript + "until 0\n"
@@ -680,9 +684,9 @@ class TestCase:
         tryRemove('registers_written')
         tryRemove('registers_read')
         # Create a script that creates the stat files. Do not overwrite
-	    # possible existing files to allow the custom simulation 
-	    # script to create a stats of its own (for example, in case of
-	    # wanting to include only a part of the simulated program in the stats)
+            # possible existing files to allow the custom simulation
+            # script to create a stats of its own (for example, in case of
+            # wanting to include only a part of the simulated program in the stats)
 
         simulationScript = simulationScript + '''
 if ![file exists cyclecount] {
@@ -691,26 +695,26 @@ flush $cycle_file
 close $cycle_file
 }
 '''
-	if not compiledSimulation:
-	        simulationScript += '''
-		if ![file exists operations_executed] {
-		set f [open operations_executed w] ; puts $f "[info stats executed_operations]"
-		flush $f
-		close $f
-		}
-		
-		if ![file exists registers_written] {
-		set f [open registers_written w] ; puts $f "[info stats register_writes]"
-		flush $f
-		close $f
-		}
-		
-		if ![file exists registers_read] {
-		set f [open registers_read w] ; puts $f "[info stats register_reads]"
-		flush $f
-		close $f
-		}
-		'''
+        if not compiledSimulation:
+                simulationScript += '''
+                if ![file exists operations_executed] {
+                set f [open operations_executed w] ; puts $f "[info stats executed_operations]"
+                flush $f
+                close $f
+                }
+
+                if ![file exists registers_written] {
+                set f [open registers_written w] ; puts $f "[info stats register_writes]"
+                flush $f
+                close $f
+                }
+
+                if ![file exists registers_read] {
+                set f [open registers_read w] ; puts $f "[info stats register_reads]"
+                flush $f
+                close $f
+                }
+                '''
         simulationScript = simulationScript + "quit\n"
 
         simulationCommand = simulatorExe
@@ -739,10 +743,10 @@ close $cycle_file
             verbose = verbose + self.simStdErr
             self.testFailed("simulation error, stderr: " + self.simStdErr );
             return False
-        
+
         def getStat(fileName):
             if access(fileName, R_OK):
-                f = __builtin__.open(fileName, "r")
+                f = builtins.open(fileName, "r")
                 try:
                     return float(f.read().strip())
                 except:
@@ -754,20 +758,20 @@ close $cycle_file
         self.lastStats.cycleCount = getStat('cyclecount')
 
         if self.lastStats.cycleCount is None:
-            self.testFailed("simulation", "failed to get cycle count " + verbose)            
+            self.testFailed("simulation", "failed to get cycle count " + verbose)
             return False
 
         if not exitOk:
 
             gotOutput = len(self.simStdOut) > 0 or len(self.simStdErr) > 0
 
-            self.testFailed("simulation", verbose)            
+            self.testFailed("simulation", verbose)
             return False
-                                                
+
         self.lastStats.operationExecutions = getStat('operations_executed')
         self.lastStats.registerReads = getStat('registers_read')
-        self.lastStats.registerWrites = getStat('registers_written')            
-        
+        self.lastStats.registerWrites = getStat('registers_written')
+
         self.stats[archFilename] = self.lastStats
         return True
 
@@ -778,30 +782,30 @@ close $cycle_file
         """
 
         global normalOutput
-        
+
         archFilename = architecture
         if not access(archFilename, R_OK):
             archFilename = ADFDir + "/" + architecture
 
         if not access(archFilename, R_OK):
-            print "Cannot find ",archFilename
+            print("Cannot find ", archFilename)
             sys.exit(2)
 
-        machineLittleEndian = "<little-endian/>" in __builtin__.open(archFilename).read()
-        machine64bits = "<bitness64/>" in __builtin__.open(archFilename).read()
+        machineLittleEndian = "<little-endian/>" in builtins.open(archFilename).read()
+        machine64bits = "<bitness64/>" in builtins.open(archFilename).read()
         if machineLittleEndian:
             if (machine64bits):
                 seqProgFile = seqProgFileBase + ".64.bc";
                 if verboseOutput:
-                    print "Machine is 64-bit. using 64 bc file."
+                    print("Machine is 64-bit. using 64 bc file.")
             else:
                 seqProgFile = seqProgFileBase + ".le.bc";
                 if verboseOutput:
-                    print "Machine is little endian. using LE bc file."
+                    print("Machine is little endian. using LE bc file.")
         else:
             seqProgFile = seqProgFileBase + ".be.bc";
             if verboseOutput:
-                print "Machine is big endian. using BE bc file."
+                print("Machine is big endian. using BE bc file.")
 
         if csvFormat:
             sys.stdout.write(self.title + "," + architecture + ",")
@@ -822,12 +826,12 @@ close $cycle_file
 
         # always write the TPEF to the current directory
         progFileName = os.getcwd() + "/" + os.path.basename(progFileName)
-        
+
         self.parallelPrograms.append(progFileName)
 
         # let's try to remove file if exists..
         tryRemove(progFileName)
-        
+
         if not self.schedule(archFilename, seqProgFile, progFileName):
             return False
 
@@ -845,7 +849,7 @@ close $cycle_file
             elif csvFormat:
                 sys.stdout.write("OK,%.0f,-,first\n"
                              % (self.lastStats.cycleCount))
-                
+
             self.improvedRuns = True
         else:
             oldResult = int(self.oldResults[architecture][-1])
@@ -867,7 +871,7 @@ close $cycle_file
                 sys.stdout.write("OK,%.0f,%.0f,%.1f%%\n"
                              % (self.lastStats.cycleCount, difference, percentage))
 
-                
+
         if normalOutput:
             if moreStats is not None:
                 for stat in moreStats:
@@ -894,12 +898,12 @@ close $cycle_file
             seqProgramNameLe = "generated_program.le.bc"
             seqProgramName64 = "generated_program.64.bc"
             compileRule = "llvm"
-            
+
             command = ("cd src;" +
                        makeCommand + ' clean;' +
-                       'SCHEDULER_TESTER_FLAGS="'  + extraFlags + '" ' +                       
+                       'SCHEDULER_TESTER_FLAGS="'  + extraFlags + '" ' +
                        makeCommand + " GCCLLVM=" + tceccExe + " " + compileRule)
-            
+
             command += ";cp " + seqProgramNameBe + " .."
             command += ";cp " + seqProgramNameLe + " .."
             command += ";cp " + seqProgramName64 + " .."
@@ -911,8 +915,8 @@ close $cycle_file
             #command += ";cp " + seqProgramName + " ../program.bc"
 
             if verboseOutput:
-                print "Compiling from sources:"
-                print command;
+                print("Compiling from sources:")
+                print(command)
 
             exitOk, stdoutContents, stderrContents = runWithTimeout(command, schedulingTimeoutSec)
 
@@ -920,27 +924,27 @@ close $cycle_file
                 self.testFailed("compiling timeout")
                 return False
 
-            errorMessage = stdoutContents + stderrContents 
-            
+            errorMessage = stdoutContents + stderrContents
+
             if not access(seqProgramNameBe, R_OK):
-                print "Error while compiling be program\n" + errorMessage
-                print "Compiler error message over\n."
+                print("Error while compiling be program\n" + errorMessage)
+                print("Compiler error message over\n.")
                 return False
 
             if not access(seqProgramNameLe, R_OK):
-                print "Error while compiling le program\n" + errorMessage
-                print "Compiler error message over\n."
+                print("Error while compiling le program\n" + errorMessage)
+                print("Compiler error message over\n.")
                 return False
 
             if not access(seqProgramName64, R_OK):
-                print "Error while compiling 64 bit program\n" + errorMessage
-                print "Compiler error message over\n."
+                print("Error while compiling 64 bit program\n" + errorMessage)
+                print("Compiler error message over\n.")
                 return False
         else:
-            print "src dir does not contain Makefile. Cannot build from src."
+            print("src dir does not contain Makefile. Cannot build from src.")
             return False
         return True
-        
+
     def run(self):
         """Runs the test case with all architectures.
 
@@ -951,7 +955,7 @@ close $cycle_file
         self.oldDir = os.getcwd()
         os.chdir(self.directory)
 
-        self.setupTestDirectory()        
+        self.setupTestDirectory()
 
         if not self.setupExecuted and access("./setup.sh", X_OK):
             callSilent("./setup.sh")
@@ -973,7 +977,7 @@ close $cycle_file
                 return False
             else:
                 seqProgFileBase = "generated_program"
-        
+
 #        if configFileDefined:
         for arch in self.architectures:
             allPassed = self.runWithArchitecture(arch, seqProgFileBase) and allPassed
@@ -981,10 +985,10 @@ close $cycle_file
                 os.chdir(self.oldDir)
                 return False
 
-        if not leaveDirty:            
+        if not leaveDirty:
             self.cleanupTestDirectory()
 
-        os.chdir(self.oldDir)        
+        os.chdir(self.oldDir)
         return allPassed
 
     def updateStatisticsFiles(self):
@@ -993,15 +997,15 @@ close $cycle_file
         This should be called only after running all test cases sucessfully, as it makes
         no sense to update the statistics if the algorithm fails for other test cases.
         """
-        timeStamp = time.strftime("%d.%m.%y %H:%M")        
-        lastRunWriter = csv.writer(__builtin__.open(self.directory + "/lastresults.csv", "w"))
+        timeStamp = time.strftime("%d.%m.%y %H:%M")
+        lastRunWriter = csv.writer(builtins.open(self.directory + "/lastresults.csv", "w"))
         for arch in self.architectures:
             lastRunWriter.writerow([arch, timeStamp, "%.0f" %
-                                    self.results[arch][0]])       
+                                    self.results[arch][0]])
 
         if (topStatsUpdates and self.improvedRuns) or baselineUpdate or loosenResults:
-            topStatsWriter = csv.writer(__builtin__.open(self.directory + "/topresults.csv", "w"))
-            
+            topStatsWriter = csv.writer(builtins.open(self.directory + "/topresults.csv", "w"))
+
             for arch in set(self.architectures + (self.oldResults and self.oldResults.keys() or [])):
                 oldResult = None
                 if self.oldResults is not None and arch in self.oldResults:
@@ -1013,7 +1017,7 @@ close $cycle_file
                     if loosenResults:
                         if oldResult is None: continue
                         # "loosen results" mode only makes some topresults worse to
-                        # give headroom for worsening (useful e.g. when supporting two LLVM 
+                        # give headroom for worsening (useful e.g. when supporting two LLVM
                         # versions)
                         if int(oldResult[-1]) < cycles:
                             topStatsWriter.writerow([arch, timeStamp, "%.0f" % cycles])
@@ -1036,9 +1040,9 @@ def get_subdirectories(root):
             found_subdirs += get_subdirectories(os.path.join(root, subdir))
             # TODO: check that same directory is not found many times in list
             #       (loop detection)
-            
-    return found_subdirs    
-        
+
+    return found_subdirs
+
 class Tester:
     """
     Test suite - responsible for running all test cases and printing out
@@ -1051,27 +1055,27 @@ class Tester:
 
     def loadTestCases(self):
         global testCaseFilters, recompile
-        
+
         self.testCases = []
-        
-        for root in get_subdirectories(testRootDir):
-            
+
+        dirs = get_subdirectories(testRootDir)
+        for root in dirs:
+
             if recompile:
                 inputProg = 'src'
             else:
                 inputProg = 'program.bc'
-            
+
             if os.access(root + "/description.txt", R_OK):
 
                 disableText = None
                 if os.access(root + "/disabled.txt", R_OK):
-                    disableFile = __builtin__.open(root + "/disabled.txt", "r")
+                    disableFile = builtins.open(root + "/disabled.txt", "r")
                     disableText =  "Reason: " + disableFile.read()
                     disableFile.close()
-                    
-                    
+
                 if disableText is None and os.access(root + "/" + inputProg, R_OK):
-                    
+
                     if testCaseFilters is not None:
                         found = False
                         for filter in testCaseFilters:
@@ -1081,40 +1085,40 @@ class Tester:
                         if not found:
                             continue
                     newCase = TestCase(root)
-                
+
                     # Push the new test case to our test case sequence
                     self.testCases.append(newCase)
 
                 #info about disabled tests (to not to forget fix them...)
-                elif normalOutput:                    
+                elif normalOutput:
                     if  not os.access(root + "/" + inputProg, R_OK):
                         disableText = inputProg + " not found"
-                        
+
                     if disableText:
-                        print ("Test in " + root +
+                        print("Test in " + root +
                                "/description.txt is disabled with selected frontend: " + disableText)
                     else:
-                        print ("Test in " + root +
+                        print("Test in " + root +
                                "/description.txt is disabled with selected frontend")
 
 
-                    
+
     def printSummary(self):
         global recompile, worsenedIsErrorLimit, failureFound
-                
+
         improved = 0
         worsened = 0
         equal = 0
         newResults = 0
-        broken = 0        
+        broken = 0
         totalCombinations = 0
         improvementSum = 0
-        worseningSum = 0    
-        
+        worseningSum = 0
+
         for testCase in self.testCases:
-            
+
             for arch in testCase.architectures:
-                
+
                 if not arch in testCase.results:
                     broken = broken + 1
                 else:
@@ -1131,7 +1135,7 @@ class Tester:
                             else:
                                 worsened = worsened + 1
                                 worseningSum = worseningSum + percentage
-                        
+
                 totalCombinations = totalCombinations + 1
 
         sys.stdout.write("SUMMARY\n")
@@ -1148,7 +1152,7 @@ class Tester:
 
         if worsened > 0:
             percentage = (worseningSum / worsened)
-            sys.stdout.write(                
+            sys.stdout.write(
                 "Worsened schedule for %d/%d case(s). Average worsening %.1f%%.\n"
                 % (worsened, totalCombinations, percentage))
             if worsenedIsErrorLimit is not None and percentage > worsenedIsErrorLimit:
@@ -1157,7 +1161,7 @@ class Tester:
                 # the previous run, try to filter these out by
                 # watching the average worsening only.
                 failureFound = True
-            
+
 
         if newResults > 0:
             sys.stdout.write(
@@ -1167,7 +1171,7 @@ class Tester:
             sys.stdout.write(
                 "Broken schedule for %d/%d case(s). Top results not updated.\n"
                 % (broken, totalCombinations))
-            
+
     def updateStatisticsFiles(self):
         for testCase in self.testCases:
             testCase.updateStatisticsFiles()
@@ -1180,9 +1184,9 @@ class Tester:
 
     def runTests(self):
         global normalOutput
-        
+
         self.initOperations()
-        
+
         testsDone = 0
         allSuccessful = True
         self.archs = []
@@ -1191,17 +1195,17 @@ class Tester:
 
             if normalOutput:
                 if len(testCase.title) > 0:
-                    print testCase.title + ":"
+                    print(testCase.title + ":")
                 if len(testCase.description) > 0:
-                    print testCase.description
+                    print(testCase.description)
 
             allSuccessful = testCase.run() and allSuccessful
-            
+
             if stopTestingAfterFailingTest and not allSuccessful:
                 return
 
             if normalOutput:
-                print
+                print()
 
             if len(self.archs) == 0:
                 for arch in testCase.architectures:
@@ -1210,21 +1214,21 @@ class Tester:
             if testsDone == 0:
                 if latexTable:
                     self.printLatexHeader()
-                
+
             if latexTable:
                 self.printLatexRow(testCase)
-                               
+
             testsDone += 1
 
         if normalOutput:
             self.printSummary()
-            
+
         if latexTable:
             self.printLatexFooter()
-        
+
         if allSuccessful:
             self.updateStatisticsFiles()
-    
+
     def printLatexHeader(self, firstColumnWidth=30, valueColumnWidth=16):
         """
         Prints the LaTeX table header.
@@ -1233,7 +1237,7 @@ class Tester:
         cols = ''
         for i in range(0, len(moreStats)*len(self.archs)):
             cols += 'l|'
-            
+
         sys.stdout.write('\\begin{tabular}{|l|%s} \hline\n' % cols)
         sys.stdout.write(''.ljust(firstColumnWidth))
         sys.stdout.write(' & ')
@@ -1247,7 +1251,7 @@ class Tester:
             archsPrinted += 1
             if archsPrinted < len(self.archs):
                 sys.stdout.write(' & ')
-        
+
         if len(moreStats) > 1:
             # Print the column headers only if there are more than one
             # column per architecture.
@@ -1263,17 +1267,17 @@ class Tester:
                     statsPrinted += 1
                     if statsPrinted < len(moreStats):
                         sys.stdout.write(' &')
-                                                                
+
                 archsPrinted += 1
                 if archsPrinted < len(self.archs):
-                    sys.stdout.write(' &')                       
-        
+                    sys.stdout.write(' &')
+
         sys.stdout.write('\\\\ \hline\n')
-    
+
     def printLatexRow(self, testCase, firstColumnWidth=30):
         """
         Prints a single row of the LaTeX table.
-        """        
+        """
         global moreStats
         sys.stdout.write(os.path.basename(testCase.directory).replace('_', '\_').ljust(firstColumnWidth))
         sys.stdout.write(' & ')
@@ -1283,18 +1287,18 @@ class Tester:
             result = testCase.stats[arch]
             sys.stdout.write(result.toLatexRow(moreStats))
             archsPrinted += 1
-            
+
             if archsPrinted < len(self.archs):
                 # More architectures going to be appended.
                 sys.stdout.write(' &')
-                
+
         sys.stdout.write('\\\\\n')
-           
+
     def printLatexFooter(self, testCase=None):
         """
         Prints the LaTeX table footer.
         """
-        sys.stdout.write('\\hline \\end{tabular}\n')        
+        sys.stdout.write('\\hline \\end{tabular}\n')
 
 
 def cleanup_and_exit(retval):
@@ -1305,10 +1309,10 @@ def cleanup_and_exit(retval):
 def main():
     global failureFound, outputOnlyIfFailure
     ParseCommandLine()
-    try:    
+    try:
         testCases = Tester()
-    except TestBenchException, e:
-        print "Error while initializing test system: " + e.getMsg()
+    except TestBenchException as e:
+        print("Error while initializing test system: " + e.getMsg())
         cleanup_and_exit(3)
 
     try:
@@ -1319,12 +1323,11 @@ def main():
             sys.__stdout__.write(sys.stdout.read())
             sys.stdout = sys.__stdout__
             cleanup_and_exit(1)
-            
-    except TestBenchException, e:
-        print "Error while running tests: " + e.getMsg()
+
+    except TestBenchException as e:
+        print("Error while running tests: " + e.getMsg())
         cleanup_and_exit(1)
-    
+
 if __name__ == '__main__':
     main()
     cleanup_and_exit(0)
-

--- a/tce/scheduler/testbench/scheduler_tester.py
+++ b/tce/scheduler/testbench/scheduler_tester.py
@@ -294,7 +294,7 @@ def runWithTimeout(command, timeoutSecs, inputStream = ""):
     if veryVerboseOutput:
         print("running: %s input-stream: %s" % (command,inputStream))
 
-    process = subprocess.Popen(command, shell=True, stdin=PIPE, stdout=stdoutFD, stderr=stderrFD, close_fds=False, text=True)
+    process = subprocess.Popen(command, shell=True, stdin=PIPE, stdout=stdoutFD, stderr=stderrFD, close_fds=False, universal_newlines=True)
 
     if process is None:
         print("Could not create process")

--- a/tce/scripts/generate_cachegrind
+++ b/tce/scripts/generate_cachegrind
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
     Copyright (c) 2002-2009 Tampere University.
@@ -27,9 +27,9 @@
 Creates a profile file loadable into kcachegrind for
 a visual profile from a ttasim trace database.
 
-@author Pekka Jääskeläinen 2009 
+@author Pekka Jääskeläinen 2009
 
-Set following settings in ttasim before initializing simulation to 
+Set following settings in ttasim before initializing simulation to
 collect the needed traces:
 
 setting procedure_transfer_tracking 1
@@ -42,12 +42,13 @@ import os.path
 
 try:
     import sqlite3
-except:
+except Exception:
     try:
-	from pysqlite2 import dbapi2 as sqlite3
-    except:
-	sys.stderr.write("pysqlite for SQLite 3 library required\n")
-	sys.exit(1)
+        from pysqlite2 import dbapi2 as sqlite3
+    except Exception:
+        sys.stderr.write("pysqlite for SQLite 3 library required\n")
+        sys.exit(1)
+
 
 class CachegrindGenerator(object):
 
@@ -91,7 +92,7 @@ class CachegrindGenerator(object):
 
         events = ["Cycles"]
         totals = [self.cycle_count]
-        if self.disasm: 
+        if self.disasm:
             events.append("NOPs")
             totals.append(self._count_nops())
 
@@ -112,11 +113,10 @@ fl=%s
 
     def _load_cycle_count(self):
         cursor = self.conn.cursor()
-        res = cursor.execute('''
+        cursor.execute('''
 SELECT integer_value FROM totals WHERE value_name = 'cycle_count';''')
-        self.cycle_count = int(res.next()[0])
+        self.cycle_count = int(cursor.fetchone()[0])
         cursor.close()
-
 
     def _load_function_address_ranges(self):
         """Loads the different data structures used to find procedure
@@ -148,7 +148,7 @@ ORDER BY first_address ASC;''')
             self.target_file.write('%d %d' % \
                         (address + self.first_address, count))
 
-            if self.disasm: 
+            if self.disasm:
                 line = self.disasm[address]
                 nops = line.count('...')
                 slots = line.count(',') + 1
@@ -169,14 +169,13 @@ ORDER BY first_address ASC;''')
                     self.target_file.write('cfn=%s\n' \
                                                'calls=%d %d\n' \
                                                '%d %d\n' % \
-                                               (call.target_func, call.total_calls, 
-                                                call.target_address + self.first_address, 
-                                                address + self.first_address, 
+                                               (call.target_func, call.total_calls,
+                                                call.target_address + self.first_address,
+                                                address + self.first_address,
                                                 call.total_inclusive_cycles))
-                        
+
         #for row in results:
-            
-            #print row
+
         cursor.close()
 
         if not got_one:
@@ -242,7 +241,7 @@ ORDER BY address ASC;
                     finished_call.target_func, finished_call.source_address,
                     finished_call.target_address))
             program_call.total_inclusive_cycles += finished_call.total_inclusive_cycles
-            program_call.total_calls += 1    
+            program_call.total_calls += 1
 
             program_call_dict[finished_call.target_address] = program_call
             program_calls[finished_call.source_address] = program_call_dict
@@ -250,7 +249,7 @@ ORDER BY address ASC;
         got_one = False
         for call_info in self.call_trace.readlines():
             cycle, address, source_address, is_return = \
-                call_info.split('\t') 
+                call_info.split('\t')
 
             cycle = int(cycle)
             address = int(address)
@@ -258,7 +257,7 @@ ORDER BY address ASC;
             is_return = bool(is_return.strip() != '0')
 
             procedure_name = find_procedure_name(address)
-                
+
             got_one = True
             if not is_return:
                 call_stack.append(TraceCall(procedure_name, address, source_address, cycle))
@@ -266,7 +265,7 @@ ORDER BY address ASC;
                 finished_call = call_stack.pop()
                 finished_call.set_end_cycle(cycle)
                 update_program_call_stats(finished_call)
-            
+
         if not got_one:
             sys.stderr.write(
                 "No call trace available. " +
@@ -277,7 +276,7 @@ ORDER BY address ASC;
         max_cycle = self.cycle_count
         # Unwind the call stack as exit has been called at some point
         # without returning from all functions (usually just _start).
-        # Need to account the unreturned function calls to the 
+        # Need to account the unreturned function calls to the
         # call profile.
         while len(call_stack) > 0:
             finished_call = call_stack.pop()
@@ -289,28 +288,30 @@ ORDER BY address ASC;
             update_program_call_stats(finished_call)
 
         self.program_calls = program_calls
-        cursor.close()        
+        cursor.close()
 
     def finish(self):
         """Flushes and closes the output and DB connections."""
         self.target_file.close()
-        self.conn.close()        
-    
+        self.conn.close()
+
+
 if __name__ == "__main__":
     try:
-        trace_file = sys.argv[1] 
-        if not os.path.exists(sys.argv[1]): raise Exception()
-    except:
+        trace_file = sys.argv[1]
+        if not os.path.exists(sys.argv[1]):
+            raise Exception()
+    except Exception:
         sys.stderr.write("Input trace database file missing.\n")
         sys.exit(1)
-    
+
     try:
         output_file = sys.argv[2]
-    except:
+    except Exception:
         output_file = trace_file + ".cachegrind"
-        
+
     gen = CachegrindGenerator(trace_file, output_file)
     gen.generate_call_data()
     gen.generate_instruction_profile()
     gen.finish()
-    
+

--- a/tce/scripts/tce-exec-bc
+++ b/tce/scripts/tce-exec-bc
@@ -1,12 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Schedules the given LLVM bitcode (2nd argument) to the target (1st argument)
-# and simulates it with ttasim. 
+# and simulates it with ttasim.
 #
 import optparse
 import tempfile
 import os.path
-import commands
+import subprocess
 import sys
 
 usage = "usage: %prog [options] adf bitcode"
@@ -25,7 +25,7 @@ if len(files) != 2:
 
 adf = files[0]
 bc = files[1]
-    
+
 scriptDir = os.path.normpath(os.path.dirname(sys.argv[0]))
 runningInstalled = 'tce/scripts' not in scriptDir
 
@@ -36,11 +36,12 @@ if not runningInstalled:
 else:
     llvmTce = "tcecc"
     ttasim = "ttasim"
-        
+
+
 def runCommand(command):
     """Runs a command."""
 
-    (exitCode, output) = commands.getstatusoutput(command)    
+    (exitCode, output) = subprocess.getstatusoutput(command)
     return (exitCode, output)
 
 tempHandle, tempFile = tempfile.mkstemp(".tpef")
@@ -48,7 +49,7 @@ tempHandle, tempFile = tempfile.mkstemp(".tpef")
 (code, out) = \
        runCommand(llvmTce + " -O0 -a " + adf + " -o " + tempFile + " " + bc)
 
-print out,
+print(out)
 
 cmd = ttasim
 
@@ -61,6 +62,4 @@ cmd += " -a " + adf + " -p " + tempFile
 
 (code, out) = runCommand(cmd)
 
-print out,
-
-#os.unlink(tempFile)
+print(out)

--- a/tce/scripts/tce-selftest
+++ b/tce/scripts/tce-selftest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8
 # Copyright (c) 2002-2019 Tampere University.
 #
@@ -30,26 +30,33 @@
 # It's sort of a "smoke test" that tells whether there is something seriously
 # broken with the TCE installation.
 #
-# (C) 2009-2019 Pekka J‰‰skel‰inen
+# (C) 2009-2019 Pekka J√§√§skel√§inen
 
 # exploit the unittest framework even though this is actually a system test
-import unittest, os, tempfile, signal, time, glob
-from subprocess import Popen, PIPE
+import unittest
+import os
+import tempfile
+import signal
+import time
+import glob
+import sys
+import shutil
+import subprocess
+
 
 class TCETestCase(unittest.TestCase):
+    prefix = None
+    minimal_adf = None
+    minimal_stdout_adf = None
 
-    def cleanup_files(self, files):
-        for f in files:
-            if os.path.exists(f):
-                os.unlink(f)
+    def setUp(self):
+        self.temp_files = []
 
-    def cleanup_dirs(self, dirs):
-        for d in dirs:
-            if os.path.exists(d):
-                os.rmdir(d)
-                
-    
-    def runWithTimeout(self, command, timeoutSecs, inputStream = ""):
+    def tearDown(self):
+        for temp_file in self.temp_files:
+            os.remove(temp_file.name)
+
+    def runWithTimeout(self, command, timeoutSecs, inputStream=""):
         """
         Runs the given process until it exits or the given time out is reached.
 
@@ -58,13 +65,13 @@ class TCETestCase(unittest.TestCase):
         timePassed = 0.0
         increment = 0.01
 
-        stderrFD, errFile = tempfile.mkstemp()
-        stdoutFD, outFile = tempfile.mkstemp()
+        process = subprocess.Popen(
+            command, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, universal_newlines=True, close_fds=False
+        )
 
-        process =  Popen(command, shell=True, stdin=PIPE, stdout=stdoutFD, stderr=stderrFD, close_fds=False)
-
-        if process == None:
-            print "Could not create process"
+        if process is None:
+            print("Could not create process")
             sys.exit(1)
 
         try:
@@ -75,73 +82,36 @@ class TCETestCase(unittest.TestCase):
 
             while True:
                 status = process.poll()
-                if status != None:
+                if status is not None:
                     # Process terminated succesfully.
-                    stdoutSize = os.lseek(stdoutFD, 0, 2)
-                    stderrSize = os.lseek(stderrFD, 0, 2)
-
-                    os.lseek(stdoutFD, 0, 0)
-                    os.lseek(stderrFD, 0, 0)
-
-                    stdoutContents = os.read(stdoutFD, stdoutSize)
-                    stderrContents = os.read(stderrFD, stderrSize)
-
-                    os.close(stdoutFD)
-                    os.remove(outFile)
-                    os.close(stderrFD)
-                    os.remove(errFile)
-                    
-                    return (False, stdoutContents, stderrContents, process.returncode)
+                    stdout, stderr = process.communicate()
+                    return (False, stdout, stderr, process.returncode)
 
                 if timePassed < timeoutSecs:
                     time.sleep(increment)
                     timePassed = timePassed + increment
                 else:
                     # time out, kill the process.
-                    stdoutSize = os.lseek(stdoutFD, 0, 2)
-                    stderrSize = os.lseek(stderrFD, 0, 2)
-
-                    os.lseek(stdoutFD, 0, 0)
-                    os.lseek(stderrFD, 0, 0)
-
-                    stdoutContents = os.read(stdoutFD, stdoutSize)
-                    stderrContents = os.read(stderrFD, stderrSize)
-
-                    os.close(stdoutFD)
-                    os.remove(outFile)
-                    os.close(stderrFD)
-                    os.remove(errFile)
                     os.kill(process.pid, signal.SIGTSTP)
-                    return (True, stdoutContents, stderrContents, process.returncode)
-        except Exception, e:
+                    stdout, stderr = process.communicate()
+                    return (True, stdout, stderr, process.returncode)
+        except Exception:
             # if something threw exception (e.g. ctrl-c)
             os.kill(process.pid, signal.SIGTSTP)
+            stdout = ''
+            stderr = ''
             try:
                 # time out, kill the process.
-                # time out, kill the process.
-                stdoutSize = os.lseek(stdoutFD, 0, 2)
-                stderrSize = os.lseek(stderrFD, 0, 2)
-
-                os.lseek(stdoutFD, 0, 0)
-                os.lseek(stderrFD, 0, 0)
-
-                stdoutContents = os.read(stdoutFD, stdoutSize)
-                stderrContents = os.read(stderrFD, stderrSize)
-
-                os.close(stdoutFD)
-                os.remove(outFile)
-                os.close(stderrFD)
-                os.remove(errFile)
-                os.kill(process.pid, signal.SIGTSTP)                
-            except:
+                os.kill(process.pid, signal.SIGTSTP)
+                stdout, stderr = process.communicate()
+            except Exception:
                 pass
 
-            return (False, stdoutContents, stderrContents, process.returncode)
+            return (False, stdout, stderr, process.returncode)
 
-    
     def get_helloWorldCFile(self):
         "Returns a .c file (name) which contains the Hello World code."
-        
+
         hello_world_c = """
             #include <stdio.h>
 
@@ -153,15 +123,18 @@ class TCETestCase(unittest.TestCase):
                 printf("World!\\n");
                 return 0;
             }
-            
+
             """
-        (fd, c_file_name) = tempfile.mkstemp(".c")
-        os.write(fd, hello_world_c)
-        os.close(fd)
-        return c_file_name
+        return self.createTempFile('.c', hello_world_c)
 
+    def createTempFile(self, suffix, content=None):
+        temp_file = tempfile.NamedTemporaryFile(mode='w', suffix=suffix, delete=False)
+        if content:
+            temp_file.write(content)
+        temp_file.close()
+        self.temp_files.append(temp_file)
+        return temp_file.name
 
-    prefix = None
     def get_tcePrefix(self):
         "Returns the path where TCE has been installed."
         if TCETestCase.prefix is None:
@@ -170,14 +143,12 @@ class TCETestCase(unittest.TestCase):
             else:
                 (timeout, TCETestCase.prefix, stderr, code) = \
                         self.runWithTimeout("tce-config --prefix", 60)
-                TCETestCase.prefix = TCETestCase.prefix and TCETestCase.prefix.strip()
-            assert TCETestCase.prefix is not None and TCETestCase.prefix != "", \
-                    "Could not find TCE prefix. Is TCE installed in PATH?"
+                TCETestCase.prefix = (
+                    TCETestCase.prefix and TCETestCase.prefix.strip()
+                )
+            assert TCETestCase.prefix, "Could not find TCE prefix. Is TCE installed in PATH?"
 
-        return TCETestCase.prefix
-
-
-    minimal_adf = None
+        return str(TCETestCase.prefix)
 
     def get_minimalADF(self):
         if TCETestCase.minimal_adf is None:
@@ -185,7 +156,6 @@ class TCETestCase(unittest.TestCase):
             assert os.path.exists(TCETestCase.minimal_adf)
         return TCETestCase.minimal_adf
 
-    minimal_stdout_adf = None
     def get_minimalStdoutADF(self):
         if TCETestCase.minimal_stdout_adf is None:
             TCETestCase.minimal_stdout_adf = self.get_tcePrefix() + "/share/tce/data/mach/minimal_with_stdout.adf"
@@ -198,105 +168,92 @@ class TestCompiler(TCETestCase):
     """Test compilation from C"""
 
     def setUp(self):
-        self.hello_world_file = self.get_helloWorldCFile()
-
-        (fd, self.ocl_kernel_fn) = tempfile.mkstemp(".cl")
-        os.write(fd, opencl_example_kernel)
-        os.close(fd)
-
-        (fd, self.ocl_host_fn) = tempfile.mkstemp(".c")
-        os.write(fd, opencl_example_host)
-        os.close(fd)
-
+        super().setUp()
+        self.ocl_kernel_fn = self.createTempFile('.cl', opencl_example_kernel)
+        self.ocl_host_fn = self.createTempFile('.c', opencl_example_host)
         self.runWithTimeout("tcecc --clear-plugin-cache", 1)
-
-    def tearDown(self):
-        os.unlink(self.hello_world_file)
-        os.unlink(self.ocl_kernel_fn)
-        os.unlink(self.ocl_host_fn)
 
     def _verify_output(self, tpef):
         (timeout, stdout, stderr, code) = \
            self.runWithTimeout("ttasim -a %s -p %s --no-debugmode" %
                                (self.get_minimalStdoutADF(), tpef), 15*60)
-        self.assertEquals(stdout.strip(), "Hello \nTTA World!")
-        self.assertEquals(stderr, "")
-        self.assertEquals(code, 0)        
-        
+        self.assertEqual(stdout.strip(), "Hello \nTTA World!")
+        self.assertEqual(stderr, "")
+        self.assertEqual(code, 0)
 
     def _test_compilation(self, switches):
-        (fd, tpef_file_name) = tempfile.mkstemp(".tpef")
-        (timeout, stdout, stderr, code) = \
-           self.runWithTimeout("tcecc %s -a %s -o %s %s" % \
-                               (switches, self.get_minimalStdoutADF(),
-                                tpef_file_name, self.get_helloWorldCFile()),
-                               20*60)
-        self.assertEquals(stdout, "")
-        self.assertEquals(stderr, "")
-        self.assertEquals(code, 0)
+        tpef_file_name = self.createTempFile('.tpef')
+        command = "tcecc {0} -a {1} -o {2} {3}".format(
+            switches, self.get_minimalStdoutADF(), tpef_file_name,
+            self.get_helloWorldCFile()
+        )
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 20*60)
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "")
+        self.assertEqual(code, 0)
 
         self._verify_output(tpef_file_name)
 
     def test_noOpt(self):
         "Test C compilation with -O0"
         self._test_compilation("-O0 --swfp")
-        
+
     def test_opt(self):
         "Test C compilation with -O3"
-        self._test_compilation("-O3") 
+        self._test_compilation("-O3")
 
     def DISABLEDtest_opencl_sa(self):
         "Test standalone OpenCL compilation if the support has been enabled"
 
-        (timeout, stdout, stderr, code) = \
-           self.runWithTimeout("tcecc --supported-languages", 20*60)
-        if "OpenCL C" not in stdout: return
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
+            "tcecc --supported-languages", 20*60
+        )
+        if "OpenCL C" not in stdout:
+            return
 
-        (fd, tpef_file_name) = tempfile.mkstemp(".tpef")
-        (timeout, stdout, stderr, code) = \
-           self.runWithTimeout("tcecc --swfp -O3 -a %s -o %s %s %s -loclhost-sa" % \
-                               (self.get_minimalStdoutADF(),
-                                tpef_file_name, self.ocl_kernel_fn, self.ocl_host_fn),
-                               20*60)
-        self.assertEquals(stdout, "You are compiling OpenCL code with software floating point emulation!\nExpect abysmal peformance!\n")
-        self.assertEquals(stderr, "")
-        self.assertEquals(code, 0)
-
-        (timeout, stdout, stderr, code) = \
-           self.runWithTimeout("ttasim -a %s -p %s --no-debugmode" %
-                               (self.get_minimalStdoutADF(), tpef_file_name), 15*60)
-        self.assertEquals(stdout.strip(), "OK")
-        self.assertEquals(stderr, "")
-        self.assertEquals(code, 0)        
+        tpef_file_name = self.createTempFile(".tpef")
+        command = "tcecc --swfp -O3 -a {0} -o {1} {2} {3} -loclhost-sa".format(
+            self.get_minimalStdoutADF(), tpef_file_name, self.ocl_kernel_fn,
+            self.ocl_host_fn
+        )
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 20*60)
+        self.assertEqual(
+            stdout,
+            "You are compiling OpenCL code with software floating point emulation!\nExpect abysmal peformance!\n"
+        )
+        self.assertEqual(stderr, "")
+        self.assertEqual(code, 0)
+        command = "ttasim -a {0} -p {1} --no-debugmode".format(
+            self.get_minimalStdoutADF(), tpef_file_name
+        )
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 15*60)
+        self.assertEqual(stdout.strip(), "OK")
+        self.assertEqual(stderr, "")
+        self.assertEqual(code, 0)
 
 
 class TestSimulator(TCETestCase):
     """Test simulating with the compiled and debugging engines."""
 
     def setUp(self):
-        if hasattr(self, 'tpef_file_name') and self.tpef_file_name is not None:
-            return
+        super().setUp()
         self.hello_world_file = self.get_helloWorldCFile()
-        (fd, self.tpef_file_name) = tempfile.mkstemp(".tpef")
-        (timeout, stdout, stderr, code) = \
-           self.runWithTimeout("tcecc %s -a %s -o %s %s" % \
-                               ("-O0 --swfp", self.get_minimalStdoutADF(),
-                                self.tpef_file_name, self.get_helloWorldCFile()),
-                               20*60)
-
-    def __del__(self):
-        os.unlink(self.tpef_file_name)
+        self.tpef_file_name = self.createTempFile(".tpef")
+        command = "tcecc -O0 --swfp -a {0} -o {1} {2}".format(
+           self.get_minimalStdoutADF(), self.tpef_file_name,
+           self.hello_world_file
+        )
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 20*60)
 
     def _test_simulation(self, switches):
-        (timeout, stdout, stderr, code) = \
-           self.runWithTimeout("ttasim %s -a %s -p %s --no-debugmode" %
-                               (switches,
-                                self.get_minimalStdoutADF(),
-                                self.tpef_file_name), 10*60)
+        command = "ttasim {0} -a {1} -p {2} --no-debugmode".format(
+            switches, self.get_minimalStdoutADF(), self.tpef_file_name
+        )
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 10*60)
         self.assertFalse(timeout)
-        self.assertEquals(stdout.strip(), "Hello \nTTA World!")
-        self.assertEquals(stderr, "")
-        self.assertEquals(code, 0)
+        self.assertEqual(stdout.strip(), "Hello \nTTA World!")
+        self.assertEqual(stderr, "")
+        self.assertEqual(code, 0)
 
     def test_debugging_simulation(self):
         "Test the debugging engine of the simulator"
@@ -304,22 +261,28 @@ class TestSimulator(TCETestCase):
 
     def test_compiled_simulation(self):
         "Test the compiled engine of the simulator"
-        self._test_simulation("-q")    
+        self._test_simulation("-q")
+
 
 class TestCustomOps(TCETestCase):
     """Test for custom op functionality"""
+
+    def setUp(self):
+        super().setUp()
+        self.temp_dir = tempfile.mkdtemp()
+        self.old_work_dir = os.getcwd()
+        os.chdir(self.temp_dir)
+
     def tearDown(self):
-        if hasattr(self, 'temp_dir'):
-            os.chdir(self.temp_dir)
-            self.cleanup_files(['hello.cc', 'hello.opb', 'hello.opp'])
-            os.chdir('..')
-            os.rmdir(self.temp_dir)
+        super().tearDown()
+        os.chdir(self.old_work_dir)
+        shutil.rmtree(self.temp_dir)
 
     def test_custom_operation_from_c_code(self):
         """Test creating a simple custom operation with simulation code and
         using it from C code"""
         opp_contents = """<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<osal version="0.1">       
+<osal version="0.1">
   <operation>
     <name>HELLO_WORLD</name>
     <description>Prints hello world to the screen. The most useful operation ever.</description>
@@ -327,12 +290,12 @@ class TestCustomOps(TCETestCase):
     <outputs>0</outputs>
     <in id="1" type="SIntWord"/>
   </operation>
-</osal> 
+</osal>
   """
         opb_src = """
 #include "OSAL.hh"
 #include <iostream>
-        
+
 OPERATION(HELLO_WORLD)
 
 TRIGGER
@@ -342,10 +305,6 @@ END_TRIGGER;
 END_OPERATION(HELLO_WORLD)
 
 """
-        esa = ""
-
-        self.temp_dir = tempfile.mkdtemp()
-        os.chdir(self.temp_dir)
         opp = open('hello.opp', 'w+')
         opp.write(opp_contents)
         opp.close()
@@ -354,67 +313,71 @@ END_OPERATION(HELLO_WORLD)
         cc.write(opb_src)
         cc.close()
 
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout('buildopset hello', 120)
-        self.assertEquals(stdout.strip(), '')
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)
-        self.assertEquals(os.path.exists('hello.opb'), True)
+        (timeout, stdout, stderr, code) = self.runWithTimeout('buildopset hello', 120)
+        self.assertEqual(stdout.strip(), '')
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
+        self.assertTrue(os.path.exists('hello.opb'))
 
-        (timeout, stdout, stderr, code) = \
-                  self.runWithTimeout(\
-            "echo 'HELLO_WORLD 0' | testosal", 120)
-        self.assertEquals(
+        (timeout, stdout, stderr, code) = self.runWithTimeout("echo 'HELLO_WORLD 0' | testosal", 120)
+        self.assertEqual(
             stdout.strip(),
-            'Hello TTA Custom Operation World!')
+            'Hello TTA Custom Operation World!'
+        )
 
 
 class TestExplorer(TCETestCase):
 
     def setUp(self):
+        super().setUp()
         self.temp_dir = tempfile.mkdtemp()
+        self.old_work_dir = os.getcwd()
         os.chdir(self.temp_dir)
-        
+
     def tearDown(self):
-        os.chdir("..")
-        os.system('rm -fr %s' % self.temp_dir)
+        super().tearDown()
+        os.chdir(self.old_work_dir)
+        shutil.rmtree(self.temp_dir)
 
     def test_default_plugins_found(self):
-        "Check that the default Explorer plugins are listed."
-        (timeout, stdout, stderr, code) = \
-                  self.runWithTimeout('explore -g', 120)
-        default_plugins = \
-          ['FrequencySweepExplorer', 'SimpleICOptimizer',
-           'RemoveUnconnectedComponents', 'MinimizeMachine',
-           'GrowMachine', 'ImmediateGenerator', 'ImplementationSelector',
-           'ComponentAdder', 'Evaluate', 'MinimalOpSet']
+        """
+        Check that the default Explorer plugins are listed.
+        """
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
+            'explore -g', 120)
+        default_plugins = [
+            'FrequencySweepExplorer', 'SimpleICOptimizer',
+            'RemoveUnconnectedComponents', 'MinimizeMachine',
+            'GrowMachine', 'ImmediateGenerator', 'ImplementationSelector',
+            'ComponentAdder', 'Evaluate', 'MinimalOpSet'
+        ]
 
         for plugin in default_plugins:
             assert plugin in stdout, '%s not found' % plugin
-        
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)
+
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
 
     def test_basic_plugins(self):
-        "Test the ImplementationSelector and Evaluate explorer plugins (this takes a while!)"
+        """
+        Test the ImplementationSelector and Evaluate explorer plugins (this
+        takes a while!)
+        """
         # Generate .idf using the ImplementationSelector plugin
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'explore -e ImplementationSelector -a %s -s1 test.dsdb' % \
-            self.get_minimalADF(), 120)
+        command = 'explore -e ImplementationSelector -a {0} -s1 test.dsdb'.format(self.get_minimalADF())
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 120)
         self.assertTrue('Best result configurations:' in stdout)
         self.assertTrue('2' in stdout)
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
 
         # Dump the .idf a file.
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
             'explore -w 2 test.dsdb', 120)
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)        
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
         self.assertTrue('Written ADF file of configuration 2' in stdout)
-        self.assertTrue('Written IDF file of configuration 2' in stdout)      
+        self.assertTrue('Written IDF file of configuration 2' in stdout)
         self.assertTrue(os.path.exists('2.adf'))
         self.assertTrue(os.path.exists('2.idf'))
 
@@ -430,57 +393,55 @@ class TestExplorer(TCETestCase):
         }
         """
 
-        os.mkdir('test_app')
-        f = open('test_app/test.c', 'w+')
+        dir_name = 'test_app'
+        os.mkdir(dir_name)
+        f = open('{0}/test.c'.format(dir_name), 'w+')
         f.write(dummy_app_c)
         f.close()
 
         # program.bc
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'tcecc test_app/test.c -c -o test_app/program.bc', 120)
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
+            'tcecc {0}/test.c -c -o {0}/program.bc'.format(dir_name), 120)
 
         # description.txt
-        f = open('test_app/description.txt', 'w+')
+        f = open('{0}/description.txt'.format(dir_name), 'w+')
         f.write("Dummy test application for explorer")
         f.close()
 
         # max_runtime
-        f = open('test_app/max_runtime', 'w+')
+        f = open('{0}/max_runtime'.format(dir_name), 'w+')
         f.write('100')
         f.close()
 
         # correct_simulation_output
-        f = open('test_app/correct_simulation_output', 'w+')
+        f = open('{0}/correct_simulation_output'.format(dir_name), 'w+')
         f.write('\n')
         f.close()
 
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'explore -v -d test_app test.dsdb', 120)
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
+            'explore -v -d {0} test.dsdb'.format(dir_name), 120)
 
-        self.assertEquals(stdout, '')
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
 
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
             'explore -e Evaluate -s 2 test.dsdb', 40*60)
 
         self.assertFalse(timeout)
         # Evaluate does not generate new configurations
         self.assertTrue('No fitting processor configurations were created.' in stdout)
         self.assertTrue(x.startswith('Warning') for x in stderr.splitlines())
-        self.assertEquals(code, 0)
+        self.assertEqual(code, 0)
 
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout('explore -c C test.dsdb', 60)
+        (timeout, stdout, stderr, code) = self.runWithTimeout('explore -c C test.dsdb', 60)
 
-        #expected_output = "| 1       | test_app         | 12          | 1.32785e-07     | 12.33              | 6262.15 |"
+        # expected_output = "| 1       | test_app         | 12          | 1.32785e-07     | 12.33              | 6262.15 |"
 
         row = stdout.split('\n')[4]
-        id, cycles, energy, delay, area = \
-            [float(x.strip()) for x in row.split('|') if x.strip() != '' and x.strip() != 'test_app']
+        id, cycles, energy, delay, area = [
+            float(x.strip()) for x in row.split('|') if x.strip() != '' and x.strip() != dir_name
+        ]
 
         """
         # Rough checks because the numbers change as the
@@ -494,58 +455,64 @@ class TestExplorer(TCETestCase):
 
         self.assertFalse(timeout)
         self.assertTrue("Configurations in DSDB" in stdout)
-        self.assertEquals(stderr, '')
-        self.assertEquals(code, 0)
+        self.assertEqual(stderr, '')
+        self.assertEqual(code, 0)
         """
+
+
 class TestEstimator(TCETestCase):
 
     def setUp(self):
+        super().setUp()
         self.temp_dir = tempfile.mkdtemp()
+        self.old_work_dir = os.getcwd()
         os.chdir(self.temp_dir)
-        
+
     def tearDown(self):
-        os.chdir("..")
-        os.system('rm -fr %s' % self.temp_dir)
+        super().tearDown()
+        os.chdir(self.old_work_dir)
+        shutil.rmtree(self.temp_dir)
 
     # Cost estimator test is disabled for now due to lack of cost data for
     # the default minimal.adf
     def _disabled_test_estimator(self):
-        "Test the cost estimator by estimating the area and delay of minimal.adf (this takes a while!)"
+        """
+        Test the cost estimator by estimating the area and delay of
+        minimal.adf (this takes a while!)
+        """
 
         # Generate .idf using explorer
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'explore -e ImplementationSelector -a %s -s 1 test.dsdb' % \
-            self.get_bigEndianMinimalADF(), 120)
+        command = 'explore -e ImplementationSelector -a {0} -s 1 test.dsdb'.format(self.get_bigEndianMinimalADF())
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 120)
         self.assertTrue('Best result configurations:' in stdout)
         self.assertTrue('2' in stdout)
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
 
         # Dump the .idf a file.
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'explore -w 2 test.dsdb', 60)
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
+            'explore -w 2 test.dsdb', 60
+        )
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
         self.assertTrue('Written ADF file of configuration 2' in stdout)
         self.assertTrue('Written IDF file of configuration 2' in stdout)
         self.assertTrue(os.path.exists('2.adf'))
         self.assertTrue(os.path.exists('2.idf'))
 
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'estimate -l -a 2.adf 2.idf', 40*60)
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
+            'estimate -l -a 2.adf 2.idf', 40*60
+        )
 
         self.assertFalse(timeout)
 
-        expected = \
+        # expected = \
         """
 total area: 4813 gates
 delay of the longest path: 12 ns
 """
 
-        #stdout = expected
+        # stdout = expected
 
         rows = stdout.split('\n')
         area = int(rows[0].split(':')[1].split(' ')[1].strip())
@@ -554,39 +521,46 @@ delay of the longest path: 12 ns
         assert area < 5400 and area > 3000, "area: %d" % area
         self.assertTrue(delay < 14)
         self.assertTrue(x.startswith('Warning') for x in stderr.splitlines())
-        self.assertEquals(code, 0)
+        self.assertEqual(code, 0)
+
 
 class TestProGeAndPIG(TCETestCase):
-    "Test the processor generator and the program image generator"
+    """
+    Test the processor generator and the program image generator
+    """
     def setUp(self):
+        super().setUp()
         self.temp_dir = tempfile.mkdtemp()
+        self.old_work_dir = os.getcwd()
         os.chdir(self.temp_dir)
 
     def tearDown(self):
-        os.chdir("..")
-        os.system('rm -fr %s' % self.temp_dir)
+        super().tearDown()
+        os.chdir(self.old_work_dir)
+        shutil.rmtree(self.temp_dir)
 
     def test_proge_and_pig(self):
-        "Test the processor generator and the program image generator (with dictionary instruction compression)"
+        """
+        Test the processor generator and the program image generator (with
+        dictionary instruction compression)
+        """
 
         # Generate .idf using the ImplementationSelector plugin
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'explore -e ImplementationSelector -a %s -s1 test.dsdb' % \
-            self.get_minimalADF(), 120)
+        command = 'explore -e ImplementationSelector -a {0} -s1 test.dsdb'.format(
+            self.get_minimalADF())
+        (timeout, stdout, stderr, code) = self.runWithTimeout(command, 120)
         self.assertTrue('Best result configurations:' in stdout)
         self.assertTrue('2' in stdout)
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
 
         # Dump the .idf a file.
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
             'explore -w 2 test.dsdb', 120)
-        self.assertEquals(stderr.strip(), '')
-        self.assertEquals(code, 0)        
+        self.assertEqual(stderr.strip(), '')
+        self.assertEqual(code, 0)
         self.assertTrue('Written ADF file of configuration 2' in stdout)
-        self.assertTrue('Written IDF file of configuration 2' in stdout)      
+        self.assertTrue('Written IDF file of configuration 2' in stdout)
         self.assertTrue(os.path.exists('2.adf'))
         self.assertTrue(os.path.exists('2.idf'))
 
@@ -602,82 +576,53 @@ class TestProGeAndPIG(TCETestCase):
         }
         """
 
-        f = open('test.c', 'w+')
-        f.write(dummy_app_c)
-        f.close()
+        c_file = self.createTempFile('.c', dummy_app_c)
 
         # test.tpef
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
-            'tcecc -O0 test.c -a 2.adf -o test.tpef', 60*10)
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
+            'tcecc -O0 {0} -a 2.adf -o test.tpef'.format(c_file), 60*10)
 
         self.assertFalse(timeout)
-        self.assertEquals(stdout, '')
-        self.assertEquals(stderr, '')
-        self.assert_(os.path.exists('test.tpef'))
-        self.assertEquals(code, 0)
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')
+        self.assertTrue(os.path.exists('test.tpef'))
+        self.assertEqual(code, 0)
 
         # generate VHDL for the processor
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
             'generateprocessor -o proc_vhdl -i 2.idf 2.adf', 60*5)
         self.assertFalse(timeout)
-        self.assertEquals(stdout, '')
-        self.assertEquals(stderr, '')
-        self.assert_(os.path.exists('proc_vhdl'))
-        self.assertEquals(code, 0)
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')
+        self.assertTrue(os.path.exists('proc_vhdl'))
+        self.assertEqual(code, 0)
 
         dir_contents = glob.glob('proc_vhdl/vhdl/*')
-        self.assertEquals(len(dir_contents), 8)
+        self.assertEqual(len(dir_contents), 8)
 
         # generate the program image
-        (timeout, stdout, stderr, code) = \
-             self.runWithTimeout(
+        (timeout, stdout, stderr, code) = self.runWithTimeout(
             'generatebits -c InstructionDictionary.so -d -g -x proc_vhdl -p test.tpef 2.adf', 60*5)
 
         self.assertFalse(timeout)
-        self.assertEquals(stdout, '')
-        self.assertEquals(stderr, '')
-        self.assertEquals(code, 0)
-        self.assertEquals('', stderr.strip())
-        self.assert_(os.path.exists('proc_vhdl/vhdl/tta0_imem_mau_pkg.vhdl'))
-        self.assert_(os.path.exists('test_data.img'))
-        self.assert_(os.path.exists('test.img'))        
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')
+        self.assertEqual(code, 0)
+        self.assertEqual('', stderr.strip())
+        self.assertTrue(os.path.exists('proc_vhdl/vhdl/tta0_imem_mau_pkg.vhdl'))
+        self.assertTrue(os.path.exists('test_data.img'))
+        self.assertTrue(os.path.exists('test.img'))
         # Probably due to Bug http://tce.cs.tut.fi/cgi-bin/tce-bugzilla/show_bug.cgi?id=114
         # this is nonempty even though we do not initialize any global data
-        #self.assertEquals(os.path.getsize('test_data.img'), 0) # No global data defs
+        # self.assertEqual(os.path.getsize('test_data.img'), 0) # No global data defs
         self.assertTrue(os.path.getsize('test.img') > 0)
-        self.assertEquals(len(open('test.img','r').readlines()[0].strip()), 6)
-        self.assertTrue('IMEMMAUWIDTH : positive := 6;' in open('proc_vhdl/vhdl/tta0_imem_mau_pkg.vhdl', 'r').read())
+        with open('test.img', 'r') as opened_file:
+            self.assertEqual(len(opened_file.readlines()[0].strip()), 6)
+        with open('proc_vhdl/vhdl/tta0_imem_mau_pkg.vhdl', 'r') as opened_file:
+            self.assertTrue('IMEMMAUWIDTH : positive := 6;' in opened_file.read())
 
-opencl_example_kernel = \
-r"""
-__attribute__((reqd_work_group_size(4, 1, 1)))
-kernel void
-dot_product (global const float4 *a,
-             global const float4 *b, 
-             global float *c,
-             local float *temp1) {
 
-    __local float temp2[4];
-    int lid = get_local_id(0);
-    int gid = get_global_id(0);
-
-    temp1[lid] = dot(a[gid], b[gid]);
-    barrier(CLK_LOCAL_MEM_FENCE);
-
-    temp2[3 - lid] = temp1[lid];
-    barrier(CLK_LOCAL_MEM_FENCE);
-
-    temp1[lid] = temp2[3 - lid];
-    barrier(CLK_LOCAL_MEM_FENCE);
-
-    c[gid] = temp1[lid];
-} 
-"""
-
-opencl_example_host = \
-r"""
+opencl_example_host = """
 #include <CL/cl.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -853,13 +798,13 @@ volatile cl_float4 inputB[TEST_SET_SIZE];
 volatile cl_float results[TEST_SET_SIZE];
 
 /* TODO: global constructor call injection breaks
-   in case main is inlined as the context is not 
+   in case main is inlined as the context is not
    saved before calling it at the moment and inlining
    brings in live variables. FIXME by doing the calls
    at LLVM Instruction level after which proper
    context saving code will be generated automatically. */
 __attribute__((noinline))
-int main() {  
+int main() {
 
     for (int i = 0; i < TEST_SET_SIZE; ++i) {
         inputA[i].s[0] = i;
@@ -874,7 +819,7 @@ int main() {
     }
 
     int retVal = exec_dot_product_kernel(
-        NULL, TEST_SET_SIZE, (void*)inputA, 
+        NULL, TEST_SET_SIZE, (void*)inputA,
         (void*)inputB, (void*)results);
 
 #ifdef DEBUG
@@ -887,7 +832,7 @@ int main() {
     int broken = 0;
     for (int i = 0; i < TEST_SET_SIZE; ++i) {
 
-        cl_float expected = 
+        cl_float expected =
             inputA[i].s[0]*inputB[i].s[0] +
             inputA[i].s[1]*inputB[i].s[1] +
             inputA[i].s[2]*inputB[i].s[2] +
@@ -895,15 +840,41 @@ int main() {
 
         if (results[i] != expected) ++broken;
     }
-    if (broken == 0) 
-        puts("OK"); 
-    else 
+    if (broken == 0)
+        puts("OK");
+    else
         puts("NOK");
     return retVal;
 }
 """
 
+opencl_example_kernel = """
+__attribute__((reqd_work_group_size(4, 1, 1)))
+kernel void
+dot_product (global const float4 *a,
+             global const float4 *b,
+             global float *c,
+             local float *temp1) {
+
+    __local float temp2[4];
+    int lid = get_local_id(0);
+    int gid = get_global_id(0);
+
+    temp1[lid] = dot(a[gid], b[gid]);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    temp2[3 - lid] = temp1[lid];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    temp1[lid] = temp2[3 - lid];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    c[gid] = temp1[lid];
+}
+"""
+
+
 if __name__ == '__main__':
-    print "Testing TCE installation, this can take up to two hours."
-    print "Time to go for a lunch? Use -v to see the progress."
+    print("Testing TCE installation, this can take up to two hours.")
+    print("Time to go for a lunch? Use -v to see the progress.")
     unittest.main()

--- a/tce/src/bintools/Compiler/tcecc.in
+++ b/tce/src/bintools/Compiler/tcecc.in
@@ -29,7 +29,7 @@
 # High-level language compiler driver for TCE.
 #
 
-import os, sys, commands, optparse, shutil, glob, signal
+import os, sys, subprocess, optparse, shutil, glob, signal
 import os.path
 import re
 
@@ -43,27 +43,29 @@ def runCommandBuffered(command, echoOutput, applyStdErr = True, stripOutput = Tr
     """Runs a command and prints everything if requested."""
 
     if echoOutput:
-        print command
+        print(command)
 
-    proc = Popen(command, shell=True, stdout = PIPE, stderr = PIPE)
+    proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
     output, errs = proc.communicate()
 
     if echoOutput:
-        print output
+        print(output)
 
     if echoOutput and applyStdErr:
-        print errs
+        print(errs)
 
+    stringOut = output.decode('utf-8')
+    stringErr = errs.decode('utf-8')
     if applyStdErr:
         if stripOutput:
-            return (proc.returncode, (output + errs).strip())
+            return (proc.returncode, (stringOut + stringErr).strip())
         else:
-            return (proc.returncode, output + errs)
+            return (proc.returncode, stringOut + stringErr)
     else:
         if stripOutput:
-            return (proc.returncode, output.strip())
+            return (proc.returncode, stringOut.strip())
         else:
-            return (proc.returncode, output)
+            return (proc.returncode, stringOut)
 
 
 # global variables...
@@ -104,7 +106,7 @@ def runCommand(command, echoOutput=True, echoStderr=False, stdoutFD=None):
     If echoOutput is False, stdout and stderr are redirected to /dev/null."""
 
     if echoOutput:
-        print command
+        print(command)
         stderrFD = None
     else:
         if stdoutFD is None:
@@ -122,19 +124,12 @@ def runCommand(command, echoOutput=True, echoStderr=False, stdoutFD=None):
     return process.wait()
 
 
-# TODO: not used anymore?
-#def is_llvm_bitcode(file_name):
-#    f = open(file_name, 'rb')
-#    magic_number = f.read(2)
-#    f.close()
-#    return magic_number == 'BC'
-
 poclInstalled = None
 poclVersion = None
 def isOpenCLEnabled():
     global poclInstalled
     if poclInstalled is not None: return poclInstalled
-    (exitCode, output) = commands.getstatusoutput("pkg-config pocl --modversion")
+    (exitCode, output) = subprocess.getstatusoutput("pkg-config pocl --modversion")
     if exitCode != 0:
         poclInstalled = False
     else:
@@ -289,8 +284,8 @@ def processInputFiles(inFiles, tmpDir, options, tceopsDir=None):
                     extra_flags = ""
                     if options.soft_float:
                         extra_flags += " POCL_VECTORIZE_NO_FP=1 "
-                        print "You are compiling OpenCL code with software floating point emulation!"
-                        print "Expect abysmal peformance!"
+                        print("You are compiling OpenCL code with software floating point emulation!")
+                        print("Expect abysmal peformance!")
 
                     input_file = baseName + suffix
                     oclextgen = os.path.join(tceOclExtGenDir, "tceoclextgen") + " "  + options.adf_file
@@ -458,7 +453,7 @@ def processInputFiles(inFiles, tmpDir, options, tceopsDir=None):
 
 def exitWithError(status, errorMessage=None):
     if errorMessage is not None:
-        print >>sys.stderr, errorMessage
+        print(errorMessage, file=sys.stderr)
     cleanup(tempDir)
     sys.exit(status)
 
@@ -731,8 +726,8 @@ def optimizeBytecode(inFile, fileNamePrefix, extraSwitches = ""):
             optSwitches += "-disable-slp-vectorization -disable-loop-vectorization"
         elif @LLVM_VERSION@ >= 9 and @LLVM_VERSION@ < 11:
             optSwitches += " -disable-slp-vectorization"
-	elif @LLVM_VERSION@ >= 11:
-	    optSwitches += " -vectorize-slp=false"
+        elif @LLVM_VERSION@ >= 11:
+            optSwitches += " -vectorize-slp=false"
 
     command = "opt -f " + inFile + " -o " + outputName + " " + optSwitches + extraSwitches
 
@@ -757,8 +752,8 @@ def linkEmulationFuncs(inFile, fileNamePrefix):
             optSwitches += " -disable-slp-vectorization -disable-loop-vectorization"
         elif @LLVM_VERSION@ >= 9 and @LLVM_VERSION@ < 11:
             optSwitches += " -disable-slp-vectorization"
-	elif @LLVM_VERSION@ >= 11:
-	    optSwitches += " -vectorize-slp=false"
+        elif @LLVM_VERSION@ >= 11:
+            optSwitches += " -vectorize-slp=false"
 
     # if software floatingpoint should be lowered, link the emulation functions in
     emulationLib = os.path.join(newlib_libdir, "float_emulation.o") + " "
@@ -883,7 +878,6 @@ class SourceLib(object):
 
         sourceFiles = [x.fullPath for x in self.sources]
 
-        #print self.compiler_options
         compilerOptions, inFiles = optionParser.parse_args(self.compiler_options)
         compilerOptions.compile_only = True
         compilerOptions.frontend_optlevel = 1
@@ -1153,8 +1147,8 @@ p.add_option('--version', action='store_true',
 """Print the tcecc version info and exit.""")
 
 p.add_option('--llvm-args', type="string",
-	     action='store', dest='llvm_args', default="",
-	     help="""Arguments passed to LLVM.""")
+             action='store', dest='llvm_args', default="",
+             help="""Arguments passed to LLVM.""")
 
 p.add_option('--dump-ddgs-dot', action='store_true', dest='dump_ddgs_dot', default=False,
              help=\
@@ -1305,7 +1299,7 @@ p.add_option('--little-endian64',
 
 p.add_option('--no-emulationlib',
              action="store_true", dest="no_emulationlib", default=False,
-	     help="Do not compile the emulationLib. Code which requires division or multiplication may fail if the processor does not have multiplier or divider." )
+             help="Do not compile the emulationLib. Code which requires division or multiplication may fail if the processor does not have multiplier or divider." )
 
 
 p.add_option('--tce-build-mode', action="store_true",
@@ -1318,9 +1312,9 @@ p.add_option('--blocks-startfiles', action="store_true",
 
 p.add_option('--assume-adf-stackalignment', action="store_true",
              dest="assume_adf_stackalignment", default=False,
-	     help="Assume that the stack alignment can be extracted by searching for the biggest memory operations found in the ADF."
-	     "When linking in dthread this option will be set automatically, dthread uses this assumption and can crash when breaking this assumption."
-	     "When using dthreads and there are bigger object in the bitcode than assumed by looking at the ADF overrule the stack alignment size manually with the -DSTACK_ALIGNMENT= argument.")
+             help="Assume that the stack alignment can be extracted by searching for the biggest memory operations found in the ADF."
+             "When linking in dthread this option will be set automatically, dthread uses this assumption and can crash when breaking this assumption."
+             "When using dthreads and there are bigger object in the bitcode than assumed by looking at the ADF overrule the stack alignment size manually with the -DSTACK_ALIGNMENT= argument.")
 # Commandline argument parsing
 
 # fix gcc switches, which cannot be represented in OptionParser format by adding extra "-" before switch
@@ -1380,13 +1374,13 @@ if options.list_langs:
     supported_languages = ["ISO C99 (c)", "C++ (c++)"]
     if isOpenCLEnabled():
         supported_languages.append("OpenCL C (cl)")
-    print "\n".join(supported_languages)
+    print("\n".join(supported_languages))
     sys.exit(0)
 
 if options.std == 'c99':
     sys.stderr.write("warning: use --std=gnu99 instead of c99 in case you use custom operations\n")
 if options.print_version:
-    print "tcecc - TCE retargetable compiler %s" % "@PACKAGE_VERSION@"
+    print("tcecc - TCE retargetable compiler %s" % "@PACKAGE_VERSION@")
     sys.exit(0)
 
 if len(inFiles) == 0:
@@ -1413,7 +1407,7 @@ tceInstalled = True
 if 'TCE_INSTALL_DIR' in os.environ.keys():
     tceprefix = os.environ['TCE_INSTALL_DIR']
 else:
-    (exitCode, output) = commands.getstatusoutput("tce-config --prefix")
+    (exitCode, output) = subprocess.getstatusoutput("tce-config --prefix")
     if exitCode != 0:
         tceInstalled = False
     else:
@@ -1559,9 +1553,9 @@ else:
 
 if options.verbose:
     if runningInstalled:
-        print "Running installed TCE from PATH."
+        print("Running installed TCE from PATH.")
     else:
-        print "Running from a TCE build tree rooted at '%s'." % "@abs_top_builddir@"
+        print("Running from a TCE build tree rooted at '%s'." % "@abs_top_builddir@")
 
 namePrefix = tempDir + "/" + os.path.basename(outputName)
 
@@ -1658,7 +1652,7 @@ else:
                 # Prefer source libraries as they work for both LE and BE,
                 # and can take in account the target specifics.
                 if options.verbose:
-                    print "note: Using source library for", i
+                    print("note: Using source library for", i)
                 slib = SourceLib(i, src_lib_path)
                 linkList += slib.build(tempDir)
                 lib_found = True
@@ -1793,7 +1787,7 @@ if options.adf_file != "":
 
     if options.disable_dsf:
         command += " --disable-dsf"
-        
+
     if options.analyze_ipatterns:
         command += " --analyze-instruction-patterns"
 
@@ -1817,7 +1811,7 @@ if options.adf_file != "":
     command += " --bypass-distance=%d" % options.bypass_distance
     command += " --bypass-distance-nodre=%d" % options.bypass_distance_nodre
     if poclInstalled:
-        (exitCode, output) = commands.getstatusoutput("pkg-config pocl --variable=libdir")
+        (exitCode, output) = subprocess.getstatusoutput("pkg-config pocl --variable=libdir")
         if exitCode == 0:
             command += " --wi-aa-filename=" + output + "/pocl/llvmopencl.so"
 

--- a/tce/tools/scripts/exec_max_time
+++ b/tce/tools/scripts/exec_max_time
@@ -1,6 +1,13 @@
-#!/usr/bin/env python
-import getopt, sys, os, time, signal, tempfile, subprocess
-        
+#!/usr/bin/env python3
+import getopt
+import sys
+import os
+import time
+import signal
+import tempfile
+import subprocess
+
+
 def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
     """
     Runs the given process until it exits or the given time out is reached.
@@ -8,10 +15,10 @@ def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
     Returns a triplet of which first value tells whether exited without timeout,
     second gives the process' output from stdout as a string, third the stderr
     """
-    
+
     timePassed = 0.0
     increment = 0.01
-    
+
     stderrFD, errFile = tempfile.mkstemp()
     stdoutFD, outFile = tempfile.mkstemp()
 
@@ -19,12 +26,12 @@ def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
     # command that is ran in the new shell.
     process =  subprocess.Popen(command, shell=True, stdin=subprocess.PIPE,
                                 stdout=stdoutFD, stderr=stderrFD, close_fds=False)
-    
+
     if verbose:
-        print "Process.pid " + str(process.pid)
-                
+        print("Process.pid " + str(process.pid))
+
     if process == None:
-        print "Could not create process"
+        print("Could not create process")
         sys.exit(1)
 
     try:
@@ -36,15 +43,15 @@ def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
         while True:
             status = process.poll()
             if status != None:
-                # Process terminated succesfully.            
+                # Process terminated succesfully.
                 stdoutSize = os.lseek(stdoutFD, 0, 2)
                 stderrSize = os.lseek(stderrFD, 0, 2)
 
                 os.lseek(stdoutFD, 0, 0)
                 os.lseek(stderrFD, 0, 0)
 
-                stdoutContents = os.read(stdoutFD, stdoutSize)
-                stderrContents = os.read(stderrFD, stderrSize)
+                stdoutContents = os.read(stdoutFD, stdoutSize).decode('utf-8')
+                stderrContents = os.read(stderrFD, stderrSize).decode('utf-8')
 
                 os.close(stdoutFD)
                 os.remove(outFile)
@@ -52,15 +59,15 @@ def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
                 os.remove(errFile)
 
                 if verbose:
-                    print "Command was executed successfully."
-                                               
+                    print("Command was executed successfully.")
+
                 return (True, stdoutContents, stderrContents)
 
             if verbose:
-                print ("Running command: " + command +
+                print("Running command: " + command +
                        " timePassed: " + str(timePassed) +
                        " limit: " + str(timeoutSecs))
-        
+
             if timePassed < timeoutSecs:
                 time.sleep(increment)
                 timePassed = timePassed + increment
@@ -73,20 +80,20 @@ def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
                 os.lseek(stdoutFD, 0, 0)
                 os.lseek(stderrFD, 0, 0)
 
-                stdoutContents = os.read(stdoutFD, stdoutSize)
-                stderrContents = os.read(stderrFD, stderrSize)
+                stdoutContents = os.read(stdoutFD, stdoutSize).decode('utf-8')
+                stderrContents = os.read(stderrFD, stderrSize).decode('utf-8')
 
                 os.close(stdoutFD)
                 os.remove(outFile)
                 os.close(stderrFD)
                 os.remove(errFile)
-            
+
                 os.kill(process.pid, signal.SIGTSTP)
                 if verbose:
-                    print "Timeout occured."
-                           
+                    print("Timeout occured.")
+
                 return (False, stdoutContents, stderrContents)
-            
+
     except:
         try:
             # Simulation time out, kill the simulated process.
@@ -96,8 +103,8 @@ def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
             os.lseek(stdoutFD, 0, 0)
             os.lseek(stderrFD, 0, 0)
 
-            stdoutContents = os.read(stdoutFD, stdoutSize)
-            stderrContents = os.read(stderrFD, stderrSize)
+            stdoutContents = os.read(stdoutFD, stdoutSize).decode('utf-8')
+            stderrContents = os.read(stderrFD, stderrSize).decode('utf-8')
 
             os.close(stdoutFD)
             os.remove(outFile)
@@ -105,38 +112,39 @@ def runWithTimeout(command, timeoutSecs, inputStream = None, verbose = False):
             os.remove(errFile)
         except:
             pass
-        
+
         # We give SIGSTPT instead SIGKILL to child process, because SIGKILL only kills given PID.
         # Popen command actually opens new shell and runs requested command in there so SIGKILL would
         # kill only the shell and leaves child command running background.
         os.kill(process.pid, signal.SIGTSTP)
 
         if verbose:
-            print "Interrupted by user."
-            
+            print("Interrupted by user.")
+
         return (False, stdoutContents, stderrContents)
-            
+
 
 def main():
     opts, args = getopt.getopt(sys.argv[1:], "v")
 
     if len(args) < 2:
-        print 'Usage: exec_max_time [-v] <time> <command>'
-        print "e.g. exec_max_time -v 10 'ls -la'"                
+        print('Usage: exec_max_time [-v] <time> <command>')
+        print("e.g. exec_max_time -v 10 'ls -la'")
         exit(0)
 
     verbose = False
-    if ('-v','') in opts:
+    if ('-v', '') in opts:
         verbose = True
-    
-    exitStatus,output,error = runWithTimeout(args[1], float(args[0]), verbose = verbose)
+
+    exitStatus, output, error = runWithTimeout(args[1], float(args[0]), verbose = verbose)
 
     sys.stdout.write(output)
     sys.stderr.write(error)
-    if exitStatus == False:
+    if not exitStatus:
         sys.exit(1)
     else:
         sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/tce/tools/scripts/systemtest.py
+++ b/tce/tools/scripts/systemtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -!- coding: utf-8 -!-
 """
     Copyright (c) 2011-2020 Pekka Jääskeläinen / Tampere University.
@@ -64,7 +64,7 @@ def run_with_timeout(command, timeoutSecs, inputStream = "", combinedOutput=True
         stdoutFD, outFile = tempfile.mkstemp()
 
     process =  Popen(command, shell=True, stdin=PIPE,
-                     stdout=stdoutFD, stderr=stderrFD, close_fds=False, text=True)
+                     stdout=stdoutFD, stderr=stderrFD, close_fds=False, universal_newlines=True)
 
     if process is None:
         print("Could not create process")


### PR DESCRIPTION
Remove Python 2 and support for Python 3 only. Python 2 is deprecated and not recommended to use anymore. I used to following scripts to test the build
```
make -j4 && tools/scripts/compiletest.sh -cq
tce-selftest -v
```

I tried to look for Python files what I could find. Some of them might not be used by the above testing scripts. Feel free to point out if I missed something. On many files I fixed formatting issues, spaces and tabs mixed to only use spaces and updated python 2 functions to use python 3 instead. Also found some already existing issues like misspelled variable names.

Comments welcome!