### PR TITLE
Blocks: Translator tool for Blocks xml to ADF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ tce/src/bintools/PIG/generatebits
 tce/src/bintools/Scheduler/buildschedulerpass
 tce/src/bintools/Scheduler/schedule
 tce/src/bintools/TPEFDumper/dumptpef
+tce/src/bintools/BlocksTranslator/blocks_translator
 tce/src/codesign/Estimator/buildestimatorplugin
 tce/test/Makefile
 tce/test/Makefile_configure_settings
@@ -180,4 +181,3 @@ tce/doc/man/TCE/algorithm.sty
 tce/doc/man/TCE/algorithmic.sty
 tce/doc/man/TCE/tce.cls
 tce/doc/man/TCE/tcedocs.cls
-

--- a/tce/CHANGES
+++ b/tce/CHANGES
@@ -1,6 +1,14 @@
 1.23       unreleased
 =====================
 
+Notable changes and features
+----------------------------
+- Experimental tool support for Blocks-CGRA [1] designs. Currently
+  tooling is limited to translation of VLIW like Blocks (xml representation)
+  to ADF file,  and re-using TCE compiler for Blocks codegeneration.
+  [1] Wijtvliet, M. (2020). Blocks, a reconfigurable architecture combining
+  energy efficiency and flexibility. Technische Universiteit Eindhoven.
+
 1.22    December 2020
 =====================
 

--- a/tce/configure.ac
+++ b/tce/configure.ac
@@ -1745,6 +1745,7 @@ AC_CONFIG_FILES([
   src/bintools/BEMViewer/Makefile
   src/bintools/Assembler/Makefile
   src/bintools/Disassembler/Makefile
+  src/bintools/BlocksTranslator/Makefile
   src/applibs/Scheduler/Selector/Makefile
   src/applibs/Scheduler/Algorithms/Makefile
   src/codesign/Makefile

--- a/tce/src/bintools/BlocksTranslator/BlocksALU.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksALU.cc
@@ -1,0 +1,165 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksALU.cc
+ *
+ * This class resembles a single output in the Blocks CGRA architecture.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#include "BlocksALU.hh"
+
+#include "ExecutionPipeline.hh"
+
+using namespace TTAMachine;
+/**
+ * Create BlocksALU with default instructions
+ *
+ * @param mach The TTA machine where the ALU needs to be added.
+ * @param name The name of the ALU.
+ * @param sources A list of sources that are attached to this unit's input.
+ * @param in1sock (shared) pointer to the TTA socket for in1 input port.
+ * @param in2sock (shared) pointer to the TTA socket for in2 input port.
+ */
+BlocksALU::BlocksALU(
+    Machine& mach, const std::string& name, std::list<std::string> sources,
+    std::shared_ptr<TTAMachine::Socket> in1sock,
+    std::shared_ptr<TTAMachine::Socket> in2sock)
+    : BlocksFU::BlocksFU(mach, name, sources, in1sock, in2sock) {
+    // Function unit and ports
+    alu = this->fu;
+
+    // HW ops
+    ops.push_back(CreateHWOp("add", 3));
+    ops.push_back(CreateHWOp("and", 3));
+    ops.push_back(CreateHWOp("eq", 3));
+    ops.push_back(CreateHWOp("ge", 3));
+    ops.push_back(CreateHWOp("geu", 3));
+    ops.push_back(CreateHWOp("gt", 3));
+    ops.push_back(CreateHWOp("gtu", 3));
+    ops.push_back(CreateHWOp("ior", 3));
+    ops.push_back(CreateHWOp("lt", 3));
+    ops.push_back(CreateHWOp("ltu", 3));
+    ops.push_back(CreateHWOp("ne", 3));
+    ops.push_back(CreateHWOp("not", 2));
+    ops.push_back(CreateHWOp("shl1_32", 2));
+    ops.push_back(CreateHWOp("shl4_32", 2));
+    ops.push_back(CreateHWOp("shr1_32", 2));
+    ops.push_back(CreateHWOp("shr4_32", 2));
+    ops.push_back(CreateHWOp("shru1_32", 2));
+    ops.push_back(CreateHWOp("shru4_32", 2));
+    ops.push_back(CreateHWOp("sub", 3));
+    ops.push_back(CreateHWOp("xor", 3));
+    ops.push_back(CreateHWOp("copy", 2));
+}
+
+/**
+ * Emulates second output port with copy of FU with input port sharing
+ *
+ * @param mach The TTA machine where the ALU pair needs to be added.
+ * @param name The name of the ALU pair.
+ * @param sources A list of sources that are attached to this unit's input.
+ * @param usesOut0 A boolean that indicates whether output port 0 of the FU is
+ * used in the CGRA.
+ * @param usesOut1 A boolean that indicates whether output port 1 of the FU is
+ * used in the CGRA.
+ */
+BlocksALUPair::BlocksALUPair(
+    TTAMachine::Machine& mach, const std::string& name,
+    std::list<std::string> sources, bool usesOut0, bool usesOut1)
+    : sources(sources) {
+    in1sock = std::make_shared<TTAMachine::Socket>(name + "_in1t");
+    in2sock = std::make_shared<TTAMachine::Socket>(name + "_in2");
+    mach.addSocket(*(in1sock.get()));
+    mach.addSocket(*(in2sock.get()));
+    if (usesOut0)
+        alu0.reset(
+            new BlocksALU(mach, name + "_out0", sources, in1sock, in2sock));
+    if (usesOut1)
+        alu1.reset(
+            new BlocksALU(mach, name + "_out1", sources, in1sock, in2sock));
+}
+
+/**
+ * Creates a hardware operation.
+ *
+ * @param name The name of the hardware operation. This needs to exactly match
+ * the name in OSEd.
+ * @param numOfOperands The number of operands that this hardware operation
+ * requires.
+ */
+HWOperation*
+BlocksALU::CreateHWOp(const std::string& name, int numOfOperands) {
+    HWOperation* op = new HWOperation(name, *alu);
+    BindPorts(op, numOfOperands);
+    ConfigurePipeline(op->pipeline(), numOfOperands);
+    return op;
+}
+
+/**
+ * Bind the operation's operands to FU ports.
+ *
+ * @param hwOp A pointer to the hardware operation of which the operands need
+ * to be binded to FU ports.
+ * @param numOfOperands The number of operands of the given hwOp.
+ */
+void
+BlocksALU::BindPorts(HWOperation* hwOp, int numOfOperands) {
+    if (numOfOperands == 2) {
+        hwOp->bindPort(1, *in1);
+        hwOp->bindPort(2, *out);
+    } else if (numOfOperands == 3) {
+        hwOp->bindPort(1, *in1);
+        hwOp->bindPort(2, *in2);
+        hwOp->bindPort(3, *out);
+    } else {
+        // Currently no operation known that uses a different numbers of
+        // operands.
+        assert(
+            false &&
+            "Trying to add an ALU operation with a different number of "
+            "operands than 2 or 3.");
+    }
+}
+
+/**
+ * Configure the operation pipeline.
+ *
+ * @param pipeline A pointer to the execution pipeline of the operation of
+ * which the pipeline needs to be configured.
+ * @param numOfOperands The number of operands of the given hwOp.
+ */
+void
+BlocksALU::ConfigurePipeline(ExecutionPipeline* pipeline, int numOfOperands) {
+    if (numOfOperands < 3) {
+        pipeline->addPortRead(1, 0, 1);
+        pipeline->addPortWrite(2, 0, 1);
+    } else {
+        pipeline->addPortRead(1, 0, 1);
+        pipeline->addPortRead(2, 0, 1);
+        pipeline->addPortWrite(3, 0, 1);
+    }
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksFU.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksFU.cc
@@ -1,0 +1,70 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksFU.cc
+ *
+ * Implementation of the virtual BlocksFU Class.
+ * This class is the parent class of ALU, LSU & MUL units.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#include "BlocksFU.hh"
+
+#include "Segment.hh"
+
+using namespace TTAMachine;
+
+/**
+ * This constructor should not be called directly.
+ */
+BlocksFU::BlocksFU(
+    TTAMachine::Machine& mach, const std::string& name,
+    std::list<std::string> sources,
+    std::shared_ptr<TTAMachine::Socket> in1sock,
+    std::shared_ptr<TTAMachine::Socket> in2sock)
+    : in1sock(in1sock), in2sock(in2sock) {
+    // Function unit and ports
+    fu = new FunctionUnit(name);
+    this->name = name;
+    this->sources = sources;
+
+    // output port suffix
+    std::string outputSuffix = name.substr(name.find("_") + 1);
+
+    in1 = new FUPort("in1t", 32, *fu, true, true, true);
+    in2 = new FUPort("in2", 32, *fu, false, false, true);
+    out = new FUPort(outputSuffix, 32, *fu, false, false, false);
+
+    // Add to machine
+    mach.addFunctionUnit(*(this->fu));
+
+    // Create output socket
+    outsock = new Socket(name);
+    mach.addSocket(*outsock);
+    in1->attachSocket(*(in1sock.get()));
+    in2->attachSocket(*(in2sock.get()));
+    out->attachSocket(*outsock);
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksGCU.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksGCU.cc
@@ -1,0 +1,151 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksGCU.cc
+ *
+ * Implementation of BlocksGCU Class.
+ * This class describes the GCU unit of the Blocks (ABU of the TTA).
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#include "BlocksGCU.hh"
+
+using namespace TTAMachine;
+/**
+ * BlocksGCU with default instructions
+ *
+ * @param mach The TTA machine where the GCU(ABU) needs to be added.
+ * @param name The name of the GCU.
+ * @param asInstr The address space containing the program instructions.
+ */
+BlocksGCU::BlocksGCU(
+    Machine& mach, const std::string& name, AddressSpace& asInstr) {
+    int delaySlots = 2;
+    int globalGuardLatency = 1;
+    gcu = new ControlUnit(name, delaySlots, globalGuardLatency);
+    mach.setGlobalControl(*gcu);
+    gcu->setAddressSpace(&asInstr);
+
+    // TODO(mm): add check if there is not already a GCU present
+    pc = new FUPort("pc", 32, *gcu, true, true, true);
+    val = new FUPort("value", 32, *gcu, false, false, true);
+    ra = new SpecialRegisterPort("ra", 32, *gcu);
+
+    // Create in and ouput sockets for 'special RA port'
+    raIn = new Socket("raIn");
+    raOut = new Socket("abu_out0");
+    valIn = new Socket("value");
+    pcIn = new Socket("pc");
+    mach.addSocket(*raIn);
+    mach.addSocket(*raOut);
+    mach.addSocket(*valIn);
+    mach.addSocket(*pcIn);
+    ra->attachSocket(*raIn);
+    ra->attachSocket(*raOut);
+    pc->attachSocket(*pcIn);
+    val->attachSocket(*valIn);
+
+    // Connect in and out socket to bus
+    const int busWidth = 32;
+    const int immWidth = 0;
+    Machine::Extension busExt = Machine::Extension::ZERO;
+    Bus* raBus = new Bus("ra_out_to_ra_in", busWidth, immWidth, busExt);
+    mach.addBus(*raBus);
+    new UnconditionalGuard(false, *raBus);
+    new Segment("seg1", *raBus);
+    raIn->attachBus(*raBus);
+    raOut->attachBus(*raBus);
+    pcIn->attachBus(*raBus);
+    raOut->setDirection(Socket::Direction::OUTPUT);
+
+    // set RA port
+    gcu->setReturnAddressPort(*ra);
+
+    // Add HWops
+    ops.push_back(CreateHWOp("bnz", 2));
+    ops.push_back(CreateHWOp("bz", 2));
+    ops.push_back(CreateHWOp("call", 1));
+    ops.push_back(CreateHWOp("jump", 1));
+}
+
+/**
+ * Configure the operation pipeline.
+ *
+ * @param pipeline A pointer to the execution pipeline of the operation of
+ * which the pipeline needs to be configured.
+ * @param numOfOperands The number of operands of the given hwOp.
+ */
+void
+BlocksGCU::ConfigurePipeline(
+    TTAMachine::ExecutionPipeline* pipeline, int numOfOperands) {
+    if (numOfOperands == 1) {
+        pipeline->addPortRead(1, 0, 1);
+    } else if (numOfOperands == 2) {
+        pipeline->addPortRead(1, 0, 1);
+        pipeline->addPortRead(2, 0, 1);
+    } else {
+        // Currently no operation known that uses a different numbers of
+        // operands.
+        assert(
+            false &&
+            "Trying to add a GCU operation with a different number of "
+            "operands than 1 or 2.");
+    }
+}
+
+/**
+ * Bind the operation's operands to GCU ports.
+ *
+ * @param hwOp A pointer to the hardware operation of which the operands need
+ * to be binded to GCU ports.
+ * @param numOfOperands The number of operands of the given hwOp.
+ */
+void
+BlocksGCU::BindPorts(TTAMachine::HWOperation* hwOp, int numOfOperands) {
+    if (numOfOperands < 2) {
+        hwOp->bindPort(1, *pc);
+    } else {
+        hwOp->bindPort(2, *pc);  // Program counter is operand 2, therfore
+                                 // port binding is switched.
+        hwOp->bindPort(1, *val);
+    }
+}
+
+/**
+ * Creates a hardware operation.
+ *
+ * @param name The name of the hardware operation. This needs to exactly match
+ * the name in OSEd.
+ * @param numOfOperands The number of operands that this hardware operation
+ * requires.
+ */
+HWOperation*
+BlocksGCU::CreateHWOp(const std::string& name, int numOfOperands) {
+    HWOperation* op = new HWOperation(name, *gcu);
+    BindPorts(op, numOfOperands);
+    ConfigurePipeline(op->pipeline(), numOfOperands);
+    return op;
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksIMM.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksIMM.cc
@@ -1,0 +1,63 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksIMM.cc
+ *
+ * Implementation of BlocksIMM Class.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#include "BlocksIMM.hh"
+
+using namespace TTAMachine;
+
+/**
+ * BlocksIMM with default instructions
+ *
+ * @param mach The TTA machine where the IU needs to be added.
+ * @param name The name of the IU.
+ * @param sources A list of sources that are attached to this unit's input.
+ */
+BlocksIMM::BlocksIMM(
+    Machine& mach, const std::string& name, std::list<std::string> sources) {
+    // IU property constants
+    unsigned int size = 1;
+    unsigned int width = 32;
+    unsigned int maxReads = 1;
+    unsigned int guardLatency = 1;
+    Machine::Extension ext = Machine::Extension::ZERO;
+
+    // Create object
+    iu = new ImmediateUnit(name, size, width, maxReads, guardLatency, ext);
+    this->sources = sources;
+    out0 = new RFPort("out0", *iu);
+    mach.addImmediateUnit(*iu);
+
+    // Create sockets
+    out0sock = new Socket(name + "_out0");
+    mach.addSocket(*out0sock);
+    out0->attachSocket(*out0sock);
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksLSU.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksLSU.cc
@@ -1,0 +1,160 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksLSU.cc
+ *
+ * Implementation of BlocksLSU Class.
+ *  This class resembles a single output in the Blocks architecture.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+#include "BlocksLSU.hh"
+
+using namespace TTAMachine;
+
+/**
+ * BlocksLSU with default instructions
+ *
+ * @param mach The TTA machine where the LSU needs to be added.
+ * @param name The name of the LSU.
+ * @param sources A list of sources that are attached to this unit's input.
+ * @param asData The address space containing the program data.
+ * @param in1sock (shared) pointer to the TTA socket for in1 input port.
+ * @param in2sock (shared) pointer to the TTA socket for in2 input port.
+ */
+BlocksLSU::BlocksLSU(
+    Machine& mach, const std::string& name, std::list<std::string> sources,
+    AddressSpace& asData, std::shared_ptr<TTAMachine::Socket> in1sock,
+    std::shared_ptr<TTAMachine::Socket> in2sock)
+    : BlocksFU::BlocksFU(mach, name, sources, in1sock, in2sock) {
+    // Function unit and ports
+    lsu = this->fu;
+    // Set adress space to data
+    lsu->setAddressSpace(&asData);
+
+    // HWOps
+    ops.push_back(CreateHWLoadOp("ld32"));
+    ops.push_back(CreateHWLoadOp("ldu16"));
+    ops.push_back(CreateHWLoadOp("ldu8"));
+    ops.push_back(CreateHWStoreOp("st16"));
+    ops.push_back(CreateHWStoreOp("st8"));
+    ops.push_back(CreateHWStoreOp("st32"));
+    ops.push_back(CreateHWLoadOp("copy"));
+}
+
+/**
+ * Constructor for BlocksLSUPair
+ *
+ * @param mach The TTA machine where the LSU pair needs to be added.
+ * @param name The name of the LSU pair.
+ * @param sources A list of sources that are attached to this unit's input.
+ * @param asData The address space containing the program data.
+ * @param usesOut0 A boolean that indicates whether output port 0 of the FU is
+ * used in the Blocks.
+ * @param usesOut1 A boolean that indicates whether output port 1 of the FU is
+ * used in the Blocks.
+ */
+BlocksLSUPair::BlocksLSUPair(
+    TTAMachine::Machine& mach, const std::string& name,
+    std::list<std::string> sources, TTAMachine::AddressSpace& asData,
+    bool usesOut0, bool usesOut1)
+    : sources(sources) {
+    in1sock = std::make_shared<TTAMachine::Socket>(name + "_in1t");
+    in2sock = std::make_shared<TTAMachine::Socket>(name + "_in2");
+    mach.addSocket(*(in1sock.get()));
+    mach.addSocket(*(in2sock.get()));
+    if (usesOut0)
+        lsu0.reset(new BlocksLSU(
+            mach, name + "_out0", sources, asData, in1sock, in2sock));
+    if (usesOut1)
+        lsu1.reset(new BlocksLSU(
+            mach, name + "_out1", sources, asData, in1sock, in2sock));
+}
+
+/**
+ * Creates a hardware load operation.
+ *
+ * @param name The name of the hardware operation. This needs to exactly match
+ * the name in OSEd.
+ */
+HWOperation*
+BlocksLSU::CreateHWLoadOp(const std::string& name) {
+    HWOperation* op = new HWOperation(name, *lsu);
+    BindPorts(op, true);
+    ConfigurePipeline(op->pipeline(), true);
+    return op;
+}
+/**
+ * Creates a hardware store operation.
+ *
+ * @param name The name of the hardware operation. This needs to exactly match
+ * the name in OSEd.
+ */
+HWOperation*
+BlocksLSU::CreateHWStoreOp(const std::string& name) {
+    HWOperation* op = new HWOperation(name, *lsu);
+    BindPorts(op, false);
+    ConfigurePipeline(op->pipeline(), false);
+    return op;
+}
+
+/**
+ * Bind the operation's operands to FU ports.
+ *
+ * @param hwOp A pointer to the hardware operation of which the operands need
+ * to be binded to FU ports.
+ * @param isLoadOp A boolean that indicates whether the operation given is a
+ * load operation(true) or store operation(false).
+ */
+void
+BlocksLSU::BindPorts(TTAMachine::HWOperation* hwOp, bool isLoadOp) {
+    if (isLoadOp) {               // Load operation
+        hwOp->bindPort(1, *in1);  // Memory address to read
+        hwOp->bindPort(2, *out);  // Data
+    } else {                      // Store operation
+        hwOp->bindPort(1, *in1);  // Memory address to write
+        hwOp->bindPort(2, *in2);  // Data to write
+    }
+}
+
+/**
+ * Configure the operation pipeline.
+ *
+ * @param pipeline A pointer to the execution pipeline of the operation of
+ * which the pipeline needs to be configured.
+ * @param isLoadOp A boolean that indicates whether the operation given is a
+ * load operation(true) or store operation(false).
+ */
+void
+BlocksLSU::ConfigurePipeline(
+    TTAMachine::ExecutionPipeline* pipeline, bool isLoadOp) {
+    if (isLoadOp) {
+        pipeline->addPortRead(1, 0, 1);
+        pipeline->addPortWrite(2, 0, 1);
+    } else {
+        pipeline->addPortRead(1, 0, 1);
+        pipeline->addPortRead(2, 0, 1);
+    }
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksMUL.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksMUL.cc
@@ -1,0 +1,148 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksMUL.cc
+ *
+ * Implementation of BlocksMUL Class.
+ * This class resembles a single output in the Blocks architecture.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#include "BlocksMUL.hh"
+
+using namespace TTAMachine;
+
+/**
+ * Constructor BlocksMUL
+ *
+ * @param mach The TTA machine where the MUL needs to be added.
+ * @param name The name of the MUL.
+ * @param sources A list of sources that are attached to this unit's input.
+ * @param in1sock (shared) pointer to the TTA socket for in1 input port.
+ * @param in2sock (shared) pointer to the TTA socket for in2 input port.
+ */
+BlocksMUL::BlocksMUL(
+    Machine& mach, const std::string& name, std::list<std::string> sources,
+    std::shared_ptr<TTAMachine::Socket> in1sock,
+    std::shared_ptr<TTAMachine::Socket> in2sock)
+    : BlocksFU::BlocksFU(mach, name, sources, in1sock, in2sock) {
+    // Function unit and ports
+    mul = this->fu;
+
+    // HW ops
+    HWOperation* mulOp = CreateHWOp("mul", 3);
+    ops.push_back(mulOp);
+    HWOperation* copyOp = CreateHWOp("copy", 2);
+    ops.push_back(copyOp);
+}
+
+/**
+ * Constructor BlocksMULPair
+ *
+ * @param mach The TTA machine where the MUL pair needs to be added.
+ * @param name The name of the MUL pair.
+ * @param sources A list of sources that are attached to this unit's input.
+ * @param usesOut0 A boolean that indicates whether output port 0 of the FU is
+ * used in the Blocks.
+ * @param usesOut1 A boolean that indicates whether output port 1 of the FU is
+ * used in the Blocks.
+ */
+BlocksMULPair::BlocksMULPair(
+    TTAMachine::Machine& mach, const std::string& name,
+    std::list<std::string> sources, bool usesOut0, bool usesOut1)
+    : sources(sources) {
+    in1sock = std::make_shared<TTAMachine::Socket>(name + "_in1t");
+    in2sock = std::make_shared<TTAMachine::Socket>(name + "_in2");
+    mach.addSocket(*(in1sock.get()));
+    mach.addSocket(*(in2sock.get()));
+    if (usesOut0)
+        mul0.reset(
+            new BlocksMUL(mach, name + "_out0", sources, in1sock, in2sock));
+    if (usesOut1)
+        mul1.reset(
+            new BlocksMUL(mach, name + "_out1", sources, in1sock, in2sock));
+}
+
+/**
+ * Creates a hardware operation.
+ *
+ * @param name The name of the hardware operation. This needs to exactly match
+ * the name in OSEd.
+ * @param numOfOperands The number of operands that this hardware operation
+ * requires.
+ */
+HWOperation*
+BlocksMUL::CreateHWOp(const std::string& name, int numOfOperands) {
+    HWOperation* op = new HWOperation(name, *mul);
+    BindPorts(op, numOfOperands);
+    ConfigurePipeline(op->pipeline(), numOfOperands);
+    return op;
+}
+
+/**
+ * Bind the operation's operands to FU ports.
+ *
+ * @param hwOp A pointer to the hardware operation of which the operands need
+ * to be binded to FU ports.
+ * @param numOfOperands The number of operands of the given hwOp.
+ */
+void
+BlocksMUL::BindPorts(HWOperation* hwOp, int numOfOperands) {
+    if (numOfOperands == 2) {
+        hwOp->bindPort(1, *in1);
+        hwOp->bindPort(2, *out);
+    } else if (numOfOperands == 3) {
+        hwOp->bindPort(1, *in1);
+        hwOp->bindPort(2, *in2);
+        hwOp->bindPort(3, *out);
+    } else {
+        // Currently no operation known that uses a different numbers of
+        // operands.
+        assert(
+            false &&
+            "Trying to add an MUL operation with a different number of "
+            "operands than 2 or 3.");
+    }
+}
+
+/**
+ * Configure the operation pipeline.
+ *
+ * @param pipeline A pointer to the execution pipeline of the operation of
+ * which the pipeline needs to be configured.
+ * @param numOfOperands The number of operands of the given hwOp.
+ */
+void
+BlocksMUL::ConfigurePipeline(ExecutionPipeline* pipeline, int numOfOperands) {
+    if (numOfOperands < 3) {
+        pipeline->addPortRead(1, 0, 1);
+        pipeline->addPortWrite(2, 0, 1);
+    } else {
+        pipeline->addPortRead(1, 0, 1);
+        pipeline->addPortRead(2, 0, 1);
+        pipeline->addPortWrite(3, 0, 1);
+    }
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksModel.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksModel.cc
@@ -1,0 +1,77 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksModel.cc
+ *
+ * Implementation of the Blocks utility class which contains a Blocks model.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#include "BlocksModel.hh"
+
+#include <exception>
+#include <iostream>
+
+using namespace std;
+
+/**
+ * Load and parse the Blocks 'architecture.xml'.
+ */
+void
+BlocksModel::LoadModelFromXml() {
+    // TODO(mm): add check for configuration bits
+    if (!VerifyXmlStructure()) return;
+
+    ObjectState* configs = mdfState_->childByName("configuration");
+    ObjectState* fuState = configs->childByName("functionalunits");
+
+    for (int i = 0; i < fuState->childCount(); i++) {
+        ObjectState* fu = fuState->child(i);
+        FunctionalUnit unit = {};
+        unit.usesOut0 = false;
+        unit.usesOut1 = false;
+        string unitTypeString = fu->stringAttribute("type");
+        unit.type = stringToEnum.at(unitTypeString);
+        unit.name = fu->stringAttribute("name");
+
+        // FU ports
+        for (int srcnum = 0; srcnum < fu->childCount(); srcnum++) {
+            ObjectState* srcPort = fu->child(srcnum);
+            unit.src.push_back(srcPort->stringAttribute("source"));
+        }
+
+        mFunctionalUnitList.push_back(unit);  // Add functional unit to list
+    }
+}
+
+/**
+ * Verify the structure of the 'architecture.xml' file.
+ */
+bool
+BlocksModel::VerifyXmlStructure() {
+    return mdfState_->hasChild("configuration") &&
+           mdfState_->hasChild("Core");
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksRF.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksRF.cc
@@ -1,0 +1,68 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksRF.cc
+ *
+ * Implementation of BlocksRF Class.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+#include "BlocksRF.hh"
+
+using namespace TTAMachine;
+/**
+ * Default blocks Regierfile model
+ *
+ * @param mach The TTA machine where the RF needs to be added.
+ * @param name The name of the RF.
+ * @param sources A list of sources that are attached to this unit's input.
+ */
+BlocksRF::BlocksRF(
+    Machine& mach, const std::string& name, std::list<std::string> sources) {
+    // Rf property constants
+    unsigned int size = 16;
+    // fixed for now, TODO: needs to be variable for mixed precision?
+    unsigned int width = 32;
+    unsigned int maxReads = 1;
+    unsigned int maxWrites = 1;
+    unsigned int guardLatency = 0;
+    TTAMachine::RegisterFile::Type type =
+        TTAMachine::RegisterFile::Type::NORMAL;
+
+    rf = new RegisterFile(
+        name, size, width, maxReads, maxWrites, guardLatency, type);
+    this->sources = sources;
+    in1 = new RFPort("in1", *rf);
+    out1 = new RFPort("out1", *rf);
+    mach.addRegisterFile(*rf);
+
+    // Create sockets
+    in1sock = new Socket(name + "_in1t");
+    out1sock = new Socket(name + "_out1");
+    mach.addSocket(*in1sock);
+    mach.addSocket(*out1sock);
+    in1->attachSocket(*in1sock);
+    out1->attachSocket(*out1sock);
+}

--- a/tce/src/bintools/BlocksTranslator/BlocksTranslator.cc
+++ b/tce/src/bintools/BlocksTranslator/BlocksTranslator.cc
@@ -1,0 +1,361 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksTranslator.cc
+ *
+ * Implementation of the translation (Blocks to TTA) functions.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#include "BlocksTranslator.hh"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "BlocksModel.hh"
+#include "ExecutionPipeline.hh"
+#include "Segment.hh"
+
+using namespace TTAMachine;
+using namespace std;
+
+/**
+ * Build the TTA model (adf file) from the Blocks model.
+ *
+ * @param BlocksModel The Blocks model created from the Blocks
+ * 'architecture.xml'.
+ * @param outputName The name of the output adf.
+ */
+void
+BlocksTranslator::BuildTTAModel(
+    BlocksModel& blocksModel, const string& outputName) {
+    Machine ttaMach;
+    ttaMach.setLittleEndian(true);
+    // Create data and instruction adress spaces
+    const int bitWidth = 8;
+    const unsigned int minAddress = 0;
+    // TODO(mm): Allow for different instr mem size than default
+    const unsigned int maxAddressInstr = 2046;
+    // TODO(mm): Allow for different data mem size than default
+    const unsigned int maxAddressData = 32768;
+    AddressSpace asData(
+        "data", bitWidth, minAddress, maxAddressData, ttaMach);
+    AddressSpace asInstr(
+        "instructions", bitWidth, minAddress, maxAddressInstr, ttaMach);
+
+    // Create a list for each functional unit type
+    list<BlocksALUPair*> aluList;
+    list<BlocksLSUPair*> lsuList;
+    list<BlocksRF*> rfList;
+    list<BlocksIMM*> iuList;
+    list<BlocksMULPair*> mulList;
+
+    // Default required unit
+    InstructionTemplate limm("limm", ttaMach);
+    BlocksGCU gcu(
+        ttaMach, "abu",
+        asInstr);  // Has to be created here so in IU slot can be added
+
+    // Check which outputs of the FU are used, each output requires a seperate
+    // TTA FU.
+    for (auto& fu : blocksModel.mFunctionalUnitList) {
+        for (auto& source : fu.src) {
+            // Split the string into FU and port
+            string sourcePort = source.substr(source.rfind(".") + 1);
+            string sourceFu = source.substr(0, source.rfind("."));
+            // Set the usesOutx to true
+            for (auto& srcFu : blocksModel.mFunctionalUnitList) {
+                if (srcFu.name == sourceFu) {
+                    if (sourcePort == "0")
+                        srcFu.usesOut0 = true;
+                    else
+                        srcFu.usesOut1 = true;
+                }
+            }
+        }
+    }
+
+    // Create for each Blocks unit a TTA unit (except default GCU and IDs)
+    for (auto& fu : blocksModel.mFunctionalUnitList) {
+        switch (fu.type) {
+            case FU_TYPE::ID:
+                break;  // Instruction decoders are not taken into account.
+            case FU_TYPE::LSU:
+                lsuList.push_back(new BlocksLSUPair(
+                    ttaMach, fu.name, fu.src, asData, fu.usesOut0,
+                    fu.usesOut1));
+                break;
+            case FU_TYPE::ALU:
+                aluList.push_back(new BlocksALUPair(
+                    ttaMach, fu.name, fu.src, fu.usesOut0, fu.usesOut1));
+                break;
+            case FU_TYPE::RF:
+                rfList.push_back(new BlocksRF(ttaMach, fu.name, fu.src));
+                break;
+            case FU_TYPE::IU:
+                iuList.push_back(new BlocksIMM(ttaMach, fu.name, fu.src));
+                if (iuList.size() == 1)
+                    limm.addSlot("ra_out_to_ra_in", 32, *(iuList.back()->iu));
+                break;
+            case FU_TYPE::MUL:
+                mulList.push_back(new BlocksMULPair(
+                    ttaMach, fu.name, fu.src, fu.usesOut0, fu.usesOut1));
+                break;
+            case FU_TYPE::ABU:
+                gcu.sources = fu.src;
+                break;
+            default:
+                try {
+                    throw "Illegal function unit type in Blocks.xml file, aborting translation. \n";
+                } catch (const char* error) {
+                    fprintf(stderr, "%s", error);
+                    Deinitialize(
+                        ttaMach, aluList, lsuList, rfList, iuList, mulList);
+                    return;
+                }
+        }
+    }
+
+    ConnectInputs(ttaMach, gcu, aluList, lsuList, rfList, mulList);
+    ttaMach.writeToADF(outputName);
+    Deinitialize(ttaMach, aluList, lsuList, rfList, iuList, mulList);
+}
+
+/**
+ * Create a connection between two different sockets.
+ * Note: Input := Bus to port, output := Port to bus.
+ *
+ * @param mach The TTA machine where the connection needs to be made.
+ * @param inputSocket A pointer to the TTA input socket that needs to be
+ * connected.
+ * @param outputSocket A pointer to the TTA output socket that needs to be
+ * connected.
+ * @param gcu A reference to the TTA GCU (ABU) model.
+ */
+Bus*
+BlocksTranslator::CreateConnection(
+    Machine& mach, Socket* inputSocket, Socket* outputSocket,
+    BlocksGCU& gcu) {
+    // TODO(mm): add exception catching where given "input" is not an input
+    // port
+    const int busWidth = 32;
+    const int immWidth = 0;
+    const string& to = inputSocket->name();
+    const string& from = outputSocket->name();
+    Machine::Extension busExt = Machine::Extension::ZERO;
+    Machine::BusNavigator busNav = mach.busNavigator();
+    const string newBusNum = to_string(busNav.count());
+    Bus* ttaBus;
+    // Verify if the socket is already attached to a bus (excluding
+    // 'ra_out_to_ra_in')
+    if (inputSocket->segmentCount() == 0) {
+        ttaBus = new Bus("bus_" + newBusNum, busWidth, immWidth, busExt);
+        mach.addBus(*ttaBus);
+        new Segment("seg1", *ttaBus);
+        if (inputSocket->name() == "ra_in" || inputSocket->name() == "pc") {
+            gcu.pcIn->attachBus(*ttaBus);
+            gcu.raIn->attachBus(*ttaBus);
+        } else {
+            inputSocket->attachBus(*ttaBus);
+        }
+    } else if (
+        inputSocket->segmentCount() == 1 &&
+        inputSocket->segment(0)->parentBus()->name() == "ra_out_to_ra_in") {
+        ttaBus = new Bus("bus_" + newBusNum, busWidth, immWidth, busExt);
+        mach.addBus(*ttaBus);
+        new Segment("seg1", *ttaBus);
+        if (inputSocket->name() == "ra_in" || inputSocket->name() == "pc") {
+            gcu.pcIn->attachBus(*ttaBus);
+            gcu.raIn->attachBus(*ttaBus);
+        } else {
+            inputSocket->attachBus(*ttaBus);
+        }
+    } else if (
+        inputSocket->segmentCount() == 2 &&
+        inputSocket->segment(0)->parentBus()->name() == "ra_out_to_ra_in") {
+        Segment* segment1 = inputSocket->segment(1);
+        ttaBus = segment1->parentBus();
+    }
+    // Not 'ra_out_to_ra_in' and segmentCount == 1
+    else {
+        Segment* segment1 = inputSocket->segment(0);
+        ttaBus = segment1->parentBus();
+    }
+    // Attach busses to sockets
+    outputSocket->attachBus(*ttaBus);
+    outputSocket->setDirection(Socket::Direction::OUTPUT);
+    return ttaBus;
+}
+
+/**
+ * Create all the connectivity in the TTA model.
+ *
+ * @param mach The TTA machine where the connections need to be made.
+ * @param gcu A reference to the TTA GCU (ABU) model.
+ * @param aluList A list with all ALU pairs currently in the TTA model.
+ * @param lsuList A list with all LSU pairs currently in the TTA model.
+ * @param rfList A list with all RFs currently in the TTA model.
+ * @param mulList A list with all MUL pairs currently in the TTA model.
+ */
+void
+BlocksTranslator::ConnectInputs(
+    TTAMachine::Machine& mach, BlocksGCU& gcu,
+    std::list<BlocksALUPair*> aluList, std::list<BlocksLSUPair*> lsuList,
+    std::list<BlocksRF*> rfList, std::list<BlocksMULPair*> mulList) {
+    Machine::SocketNavigator nav = mach.socketNavigator();
+    // Create ALU connections (all connections that are an input to the ALUs)
+    for (auto& blocksAlu : aluList) {
+        for (auto& source : blocksAlu->sources) {
+            Socket* outputSocket = FindOutputSocket(nav, source);
+            CreateConnection(
+                mach, blocksAlu->in1sock.get(), outputSocket, gcu);
+            CreateConnection(
+                mach, blocksAlu->in2sock.get(), outputSocket, gcu);
+        }
+    }
+
+    // Create LSU connections (all connections that are an input to the LSUs)
+    for (auto& lsu : lsuList) {
+        for (auto& source : lsu->sources) {
+            Socket* outputSocket = FindOutputSocket(nav, source);
+            CreateConnection(mach, lsu->in1sock.get(), outputSocket, gcu);
+            CreateConnection(mach, lsu->in2sock.get(), outputSocket, gcu);
+        }
+    }
+
+    // Create MUL connections (all connections that are an input to the MULs)
+    for (auto& mul : mulList) {
+        for (auto& source : mul->sources) {
+            Socket* outputSocket = FindOutputSocket(nav, source);
+            CreateConnection(mach, mul->in1sock.get(), outputSocket, gcu);
+            CreateConnection(mach, mul->in2sock.get(), outputSocket, gcu);
+        }
+    }
+
+    // Create RF connections (all connections that are an input to the RFs)
+    for (auto& rf : rfList) {
+        for (auto& source : rf->sources) {
+            Socket* outputSocket = FindOutputSocket(nav, source);
+            CreateConnection(mach, rf->in1sock, outputSocket, gcu);
+        }
+    }
+
+    // IMM has no input socket so is skipped.
+    // Create GCU connections
+    for (auto& source : gcu.sources) {
+        Socket* outputSocket = FindOutputSocket(nav, source);
+        CreateConnection(mach, gcu.pcIn, outputSocket, gcu);
+        CreateConnection(mach, gcu.valIn, outputSocket, gcu);
+    }
+}
+
+/**
+ * Find the output socket corresponding to a FU name.
+ *
+ * @param nav An instance of a socketnavigator.
+ * @param source The source of which the handle to the output socket needs to
+ * be returned.
+ */
+Socket*
+BlocksTranslator::FindOutputSocket(
+    Machine::SocketNavigator nav, string source) {
+    // String manipulation to get the right format
+    source.replace(source.rfind("."), 1, "_out");
+    assert(
+        nav.hasItem(source) &&
+        "Cannot create connection, output socket not found!");
+    return nav.item(source);
+}
+
+/**
+ * Clean up the memory, deletes all FUs and busses.
+ *
+ * @param mach The TTA machine where the connections need to be made.
+ * @param aluList A list with all ALU pairs currently in the TTA model.
+ * @param lsuList A list with all LSU pairs currently in the TTA model.
+ * @param rfList A list with all RFs currently in the TTA model.
+ * @param mulList A list with all MUL pairs currently in the TTA model.
+ */
+void
+BlocksTranslator::Deinitialize(
+    TTAMachine::Machine& mach, std::list<BlocksALUPair*> aluList,
+    std::list<BlocksLSUPair*> lsuList, std::list<BlocksRF*> rfList,
+    std::list<BlocksIMM*> iuList, std::list<BlocksMULPair*> mulList) {
+    while (!aluList.empty()) {
+        delete aluList.front();
+        aluList.pop_front();
+    }
+    while (!lsuList.empty()) {
+        delete lsuList.front();
+        lsuList.pop_front();
+    }
+    while (!rfList.empty()) {
+        delete rfList.front();
+        rfList.pop_front();
+    }
+    while (!iuList.empty()) {
+        delete iuList.front();
+        iuList.pop_front();
+    }
+    while (!mulList.empty()) {
+        delete mulList.front();
+        mulList.pop_front();
+    }
+    // Delete busses
+    Machine::BusNavigator busNav = mach.busNavigator();
+    while (busNav.count() != 0) {
+        Bus* toDelete = busNav.item(busNav.count() - 1);
+        delete toDelete->segment(0);
+        delete toDelete;
+    }
+}
+
+/**
+ * main()
+ */
+int
+main(int argc, char* argv[]) {
+    // Define a structured way to represent the .xml architecture.
+    // Verify input arguments and open xml file.
+    try {
+        if (argc != 3)
+            throw "Invalid number of arguments, expected 2 arguments. \n";
+    } catch (const char* error) {
+        fprintf(stderr, "%s", error);
+        fprintf(
+            stdout,
+            "Expected path to .xml file with Blocks architecture and name of "
+            "output architecture (<name>.adf). \n");
+        return 1;
+    }
+
+    const string filepath = string(argv[1]);
+    const string outputFileName = string(argv[2]);
+
+    BlocksModel blocksModel(filepath);
+    BlocksTranslator::BuildTTAModel(blocksModel, outputFileName);
+}

--- a/tce/src/bintools/BlocksTranslator/Makefile.am
+++ b/tce/src/bintools/BlocksTranslator/Makefile.am
@@ -1,0 +1,39 @@
+PROJECT_ROOT = $(top_srcdir)
+SRC_ROOT_DIR = ${PROJECT_ROOT}/src
+
+LIB_TCETOOLS_DIR = ../../tools
+LIB_BASE_DIR = ../../base
+ROOT_DIR = ../../..
+
+OSAL_DIR = ${SRC_ROOT_DIR}/base/osal
+TPEF_DIR = ${SRC_ROOT_DIR}/base/tpef
+MACH_DIR = ${SRC_ROOT_DIR}/base/mach
+UMACH_DIR = ${SRC_ROOT_DIR}/base/umach
+TOOLS_DIR = ${SRC_ROOT_DIR}/tools
+
+PROGRAM_DIR = ${SRC_ROOT_DIR}/base/program
+
+APPLIBS_MACH_DIR = ../../applibs/mach
+APPLIBS_FSA_DIR = ../../applibs/FSA
+
+BLOCKS_TRANS_INC_DIR = ./include
+
+bin_PROGRAMS = blocks_translator
+
+blocks_translator_SOURCES = BlocksTranslator.cc BlocksFU.cc BlocksLSU.cc \
+        BlocksALU.cc BlocksGCU.cc BlocksRF.cc BlocksIMM.cc BlocksMUL.cc \
+        BlocksModel.cc
+blocks_translator_LDADD = ../../libtce.la
+
+AM_CPPFLAGS = -I${LIB_TCETOOLS_DIR} -I${ROOT_DIR} -I${OSAL_DIR} \
+        -I${SIM_APPLIB_DIR} -I${INT_APPLIB_DIR} -I${LIB_BASE_DIR} \
+        -I${MACH_DIR} -I${UMACH_DIR} -I$(PROGRAM_DIR) -I$(TPEF_DIR) \
+        -I${APPLIBS_MACH_DIR} -I${TOOLS_DIR} -I${BLOCKS_TRANS_INC_DIR}
+AM_CPPFLAGS += -I${PROJECT_ROOT} # Needed for config.h
+
+AM_LDFLAGS = ${TCE_LDFLAGS}
+
+dist-hook:
+	rm -rf $(distdir)/CVS $(distdir)/.deps $(distdir)/Makefile
+
+MAINTAINERCLEANFILES = *~ *.gcov *.bbg *.bb *.da

--- a/tce/src/bintools/BlocksTranslator/include/BlocksALU.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksALU.hh
@@ -1,0 +1,77 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksALU.hh
+ *
+ * Declaration of BlocksALU Class.
+ * This class resembles a single output in the Blocks architecture.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_ALU_HH
+#define BLOCKS_ALU_HH
+
+#include "BlocksFU.hh"
+
+class BlocksALU : public BlocksFU {
+public:
+    TTAMachine::FunctionUnit* alu;
+    BlocksALU(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources,
+        std::shared_ptr<TTAMachine::Socket> in1sock,
+        std::shared_ptr<TTAMachine::Socket> in2sock);
+    ~BlocksALU() {
+        while (!ops.empty()) {
+            delete ops.back();
+            ops.pop_back();
+        }
+    }
+
+private:
+    void ConfigurePipeline(
+        TTAMachine::ExecutionPipeline* pipeline, int numOfOperands);
+    void BindPorts(TTAMachine::HWOperation* hwOp, int numOfOperands);
+    TTAMachine::HWOperation* CreateHWOp(
+        const std::string& name, int numOfOperands);
+};
+
+class BlocksALUPair {
+public:
+    // Smart pointers for automated memory management
+    std::unique_ptr<BlocksALU> alu0;
+    std::unique_ptr<BlocksALU> alu1;
+    std::shared_ptr<TTAMachine::Socket> in1sock;
+    std::shared_ptr<TTAMachine::Socket> in2sock;
+    std::list<std::string> sources;
+
+    BlocksALUPair(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources, bool usesOut0, bool usesOut1);
+
+private:
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksFU.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksFU.hh
@@ -1,0 +1,70 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksFU.hh
+ *
+ * Declaration of the virtual BlocksFU Class.
+ * This class is the parent class of ALU, LSU & MUL units.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_FU_HH
+#define BLOCKS_FU_HH
+
+#include <memory>
+
+#include "BlocksGCU.hh"
+#include "Machine.hh"
+#include "Socket.hh"
+
+class BlocksFU {
+protected:
+    BlocksFU(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources,
+        std::shared_ptr<TTAMachine::Socket> in1sock,
+        std::shared_ptr<TTAMachine::Socket> in2sock);
+    ~BlocksFU() {
+        delete in1;
+        delete in2;
+        delete out;
+        delete outsock;
+        delete fu;
+    }
+
+public:
+    std::vector<TTAMachine::HWOperation*> ops;
+    TTAMachine::FunctionUnit* fu;
+    TTAMachine::FUPort* in1;
+    TTAMachine::FUPort* in2;
+    TTAMachine::FUPort* out;
+    std::shared_ptr<TTAMachine::Socket> in1sock;
+    std::shared_ptr<TTAMachine::Socket> in2sock;
+    TTAMachine::Socket* outsock;
+    std::list<std::string> sources;
+    std::string name;
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksGCU.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksGCU.hh
@@ -1,0 +1,84 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksGCU.hh
+ *
+ * This class describes the GCU unit of the Blocks (ABU of the TTA).
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_GCU_HH
+#define BLOCKS_GCU_HH
+
+#include "ControlUnit.hh"
+#include "ExecutionPipeline.hh"
+#include "FUPort.hh"
+#include "Guard.hh"
+#include "HWOperation.hh"
+#include "Machine.hh"
+#include "Segment.hh"
+#include "Socket.hh"
+#include "SpecialRegisterPort.hh"
+
+class BlocksGCU {
+public:
+    TTAMachine::ControlUnit* gcu;
+    BlocksGCU(
+        TTAMachine::Machine& mach, const std::string& name,
+        TTAMachine::AddressSpace& asInstr);
+    TTAMachine::FUPort* pc;
+    TTAMachine::FUPort* val;
+    TTAMachine::SpecialRegisterPort* ra;
+    TTAMachine::Socket* raIn;
+    TTAMachine::Socket* raOut;
+    TTAMachine::Socket* pcIn;
+    TTAMachine::Socket* valIn;
+    TTAMachine::Bus* raBus;
+    std::list<std::string> sources;
+    ~BlocksGCU() {
+        delete pc;
+        delete val;
+        delete ra;
+        while (!ops.empty()) {
+            delete ops.back();
+            ops.pop_back();
+        }
+        delete raIn;
+        delete raOut;
+        delete valIn;
+        delete pcIn;
+        delete gcu;
+    }
+
+private:
+    std::vector<TTAMachine::HWOperation*> ops;
+    void ConfigurePipeline(
+        TTAMachine::ExecutionPipeline* pipeline, int numOfOperands);
+    void BindPorts(TTAMachine::HWOperation* hwOp, int numOfOperands);
+    TTAMachine::HWOperation* CreateHWOp(
+        const std::string& name, int numOfOperands);
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksIMM.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksIMM.hh
@@ -1,0 +1,55 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksIMM.hh
+ *
+ * Declaration of BlocksIMM Class.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_IMM_HH
+#define BLOCKS_IMM_HH
+
+#include "Machine.hh"
+#include "RegisterFile.hh"
+
+class BlocksIMM {
+public:
+    TTAMachine::ImmediateUnit* iu;
+    BlocksIMM(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources);
+    TTAMachine::RFPort* out0;
+    TTAMachine::Socket* out0sock;
+    std::list<std::string> sources;
+
+    ~BlocksIMM() {
+        delete out0;
+        delete out0sock;
+        delete iu;
+    }
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksLSU.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksLSU.hh
@@ -1,0 +1,84 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksLSU.hh
+ *
+ * Declaration of BlocksLSU Class.
+ *  This class resembles a single output in the Blocks architecture.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_LSU_HH
+#define BLOCKS_LSU_HH
+
+#include <memory>
+
+#include "BlocksFU.hh"
+
+class BlocksLSU : public BlocksFU {
+public:
+    TTAMachine::FunctionUnit* lsu;
+    BlocksLSU(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources, TTAMachine::AddressSpace& asData,
+        std::shared_ptr<TTAMachine::Socket> in1sock,
+        std::shared_ptr<TTAMachine::Socket> in2sock);
+    ~BlocksLSU() {
+        while (!ops.empty()) {
+            delete ops.back();
+            ops.pop_back();
+        }
+    }
+
+private:
+    void ConfigurePipeline(
+        TTAMachine::ExecutionPipeline* pipeline, bool isLoadOp);
+    void BindPorts(TTAMachine::HWOperation* hwOp, bool isLoadOp);
+    TTAMachine::HWOperation* CreateHWLoadOp(const std::string& name);
+    TTAMachine::HWOperation* CreateHWStoreOp(const std::string& name);
+};
+
+/* Declaration of BlocksLSUPair Class. This class is a wrapper for BlocksLSU
+ * class to group two units both representing a different output of the same
+ * Blocks Unit.
+ */
+class BlocksLSUPair {
+public:
+    // Smart pointers for automated memory management
+    std::unique_ptr<BlocksLSU> lsu0;
+    std::unique_ptr<BlocksLSU> lsu1;
+    std::shared_ptr<TTAMachine::Socket> in1sock;
+    std::shared_ptr<TTAMachine::Socket> in2sock;
+    std::list<std::string> sources;
+
+    BlocksLSUPair(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources, TTAMachine::AddressSpace& asData,
+        bool usesOut0, bool usesOut1);
+
+private:
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksMUL.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksMUL.hh
@@ -1,0 +1,82 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksMUL.hh
+ *
+ * Declaration of BlocksMUL Class.
+ * This class resembles a single output in the Blocks architecture.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_MUL_HH
+#define BLOCKS_MUL_HH
+
+#include "BlocksFU.hh"
+
+class BlocksMUL : public BlocksFU {
+public:
+    TTAMachine::FunctionUnit* mul;
+    BlocksMUL(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources,
+        std::shared_ptr<TTAMachine::Socket> in1sock,
+        std::shared_ptr<TTAMachine::Socket> in2sock);
+    ~BlocksMUL() {
+        while (!ops.empty()) {
+            delete ops.back();
+            ops.pop_back();
+        }
+    }
+
+private:
+    void ConfigurePipeline(
+        TTAMachine::ExecutionPipeline* pipeline, int numOfOperands);
+    void BindPorts(TTAMachine::HWOperation* hwOp, int numOfOperands);
+    TTAMachine::HWOperation* CreateHWOp(
+        const std::string& name, int numOfOperands);
+};
+
+/**
+ * This class is a wrapper for BlocksMUL
+ * class to group two units both representing a different output of the same
+ * Blocks Unit.
+ */
+class BlocksMULPair {
+public:
+    // Smart pointers for automated memory management
+    std::unique_ptr<BlocksMUL> mul0;
+    std::unique_ptr<BlocksMUL> mul1;
+    std::shared_ptr<TTAMachine::Socket> in1sock;
+    std::shared_ptr<TTAMachine::Socket> in2sock;
+    std::list<std::string> sources;
+
+    BlocksMULPair(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources, bool usesOut0, bool usesOut1);
+
+private:
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksModel.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksModel.hh
@@ -1,0 +1,90 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksModel.hh
+ *
+ * Declaration of the BlocksModel class which contains a Blocks model.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_MODEL_HH
+#define BLOCKS_MODEL_HH
+
+#include <list>
+#include <map>
+#include <string>
+
+#include "ObjectState.hh"
+#include "XMLSerializer.hh"
+
+namespace BlocksTranslator {
+enum class FU_TYPE {
+    ID,
+    IU,  // Immediate unit
+    ALU,
+    RF,
+    MUL,
+    LSU,  // Load store unit
+    ABU
+};
+}
+
+class BlocksModel {
+private:
+    void LoadModelFromXml();
+    bool VerifyXmlStructure();
+
+    const std::map<std::string, BlocksTranslator::FU_TYPE> stringToEnum{
+        {"ID", BlocksTranslator::FU_TYPE::ID},
+        {"ABU", BlocksTranslator::FU_TYPE::ABU},
+        {"IU", BlocksTranslator::FU_TYPE::IU},
+        {"LSU", BlocksTranslator::FU_TYPE::LSU},
+        {"ALU", BlocksTranslator::FU_TYPE::ALU},
+        {"RF", BlocksTranslator::FU_TYPE::RF},
+        {"MUL", BlocksTranslator::FU_TYPE::MUL}};
+
+    struct FunctionalUnit {
+        BlocksTranslator::FU_TYPE type;
+        std::string name;
+        std::list<std::string> src;
+        bool usesOut0;
+        bool usesOut1;
+        // TODO(mm): add config bit
+    };
+
+    ObjectState* mdfState_;
+
+public:
+    // Parse Blocks architecture into program memory
+    BlocksModel(std::string filename) {
+        XMLSerializer* serializer = new XMLSerializer();
+        serializer->setSourceFile(filename);
+        mdfState_ = serializer->readState();
+        LoadModelFromXml();
+    };
+    std::list<FunctionalUnit> mFunctionalUnitList;
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksRF.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksRF.hh
@@ -1,0 +1,61 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksRF.hh
+ *
+ * Declaration of BlocksRF Class.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_RF_HH
+#define BLOCKS_RF_HH
+
+#include "HWOperation.hh"
+#include "Machine.hh"
+#include "Socket.hh"
+#include "SpecialRegisterPort.hh"
+
+class BlocksRF {
+public:
+    TTAMachine::RegisterFile* rf;
+    BlocksRF(
+        TTAMachine::Machine& mach, const std::string& name,
+        std::list<std::string> sources);
+    TTAMachine::RFPort* in1;
+    TTAMachine::RFPort* out1;
+    TTAMachine::Socket* in1sock;
+    TTAMachine::Socket* out1sock;
+    std::list<std::string> sources;
+
+    ~BlocksRF() {
+        delete out1;
+        delete in1;
+        delete in1sock;
+        delete out1sock;
+        delete rf;
+    }
+};
+#endif

--- a/tce/src/bintools/BlocksTranslator/include/BlocksTranslator.hh
+++ b/tce/src/bintools/BlocksTranslator/include/BlocksTranslator.hh
@@ -1,0 +1,69 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksTranslator.hh
+ *
+ * Declaration of the Blocks translator (Blocks to TTA) functions.
+ *
+ * @author Maarten Molendijk 2020 (m.j.molendijk@tue.nl)
+ * @author Kanishkan Vadivel 2021 (k.vadivel@tue.nl)
+ */
+
+#ifndef BLOCKS_TRANSLATOR_HH
+#define BLOCKS_TRANSLATOR_HH
+
+#include "BlocksALU.hh"
+#include "BlocksGCU.hh"
+#include "BlocksIMM.hh"
+#include "BlocksLSU.hh"
+#include "BlocksMUL.hh"
+#include "BlocksModel.hh"
+#include "BlocksRF.hh"
+#include "ControlUnit.hh"
+#include "FUPort.hh"
+#include "FunctionUnit.hh"
+#include "HWOperation.hh"
+#include "ImmediateUnit.hh"
+#include "Socket.hh"
+#include "SpecialRegisterPort.hh"
+
+namespace BlocksTranslator {
+void BuildTTAModel(BlocksModel& blocksModel, const std::string& outputName);
+TTAMachine::Bus* CreateConnection(
+    TTAMachine::Machine& mach, TTAMachine::Socket* inputSocket,
+    TTAMachine::Socket* outputSocket, BlocksGCU& gcu);
+
+void Deinitialize(
+    TTAMachine::Machine& mach, std::list<BlocksALUPair*> aluList,
+    std::list<BlocksLSUPair*> lsuList, std::list<BlocksRF*> rfList,
+    std::list<BlocksIMM*> iuList, std::list<BlocksMULPair*> mulList);
+
+void ConnectInputs(
+    TTAMachine::Machine& mach, BlocksGCU& gcu,
+    std::list<BlocksALUPair*> aluList, std::list<BlocksLSUPair*> lsuList,
+    std::list<BlocksRF*> rfList, std::list<BlocksMULPair*> mulList);
+TTAMachine::Socket* FindOutputSocket(
+    TTAMachine::Machine::SocketNavigator nav, std::string source);
+}  // namespace BlocksTranslator
+#endif

--- a/tce/src/bintools/Makefile.am
+++ b/tce/src/bintools/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = DictionaryTool TPEFDumper PIG BEMGenerator Assembler \
-          BEMViewer Disassembler
+          BEMViewer Disassembler BlocksTranslator
 
 if LLVM
     SUBDIRS += Compiler

--- a/testsuite/systemtest/bintools/BlocksTools/data/generic_blocks_vliw_arch.xml
+++ b/testsuite/systemtest/bintools/BlocksTools/data/generic_blocks_vliw_arch.xml
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture>
+    <!-- Use 'hdl_param=name' to identify parameters '<<name>>' that are replaced in the HDL code-->
+    <!-- By default this file EXTENDS(!) the included configurations. If you want to OVERRIDE a section, add the override='true' attribute to the tag you want to override -->
+
+    <Includes>
+        <!-- Inherit from base configuration -->
+        <Base file="../../Common/32b.xml"/>
+    </Includes>
+
+    <configuration>
+
+        <functionalunits>
+
+
+            <!-- ISSUE SLOT 1 -->
+            <fu type="ID" name='S1_id_abu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ABU" name='S1_abu' ID="S1_id_abu" config="1">
+                <input index="0" source="S1_imm.0"/>
+                <input index="1" source="S1_rf.1"/>
+                <input index="2" source="S1_alu.0"/>
+            </fu>
+
+            <fu type="IU" name='S1_imm'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S1_id_lsu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S1_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S1_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S1_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S1_mul' ID="S1_id_mul" config="1">
+                <input index="1" source="S1_rf.1"/>
+                <input index="2" source="S8_rf.1"/>
+                <input index="3" source="S2_rf.1"/>
+            </fu>
+
+            <fu type="ALU" name='S1_alu' ID="S1_id_alu" config="1">
+                <input index="1" source="S1_rf.1"/>
+                <input index="2" source="S1_alu.0"/>
+                <input index="3" source="S1_mul.0"/>
+            </fu>
+
+            <fu type="LSU" name='S1_lsu' ID="S1_id_lsu" config="1">
+                <input index="1" source="S1_rf.1"/>
+                <input index="2" source="S1_alu.0"/>
+                <input index="3" source="S1_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S1_rf' ID="S1_id_rf">
+                <input index="0" source="S1_alu.0"/>
+                <input index="1" source="S1_mul.0"/>
+                <input index="2" source="S1_lsu.0"/>
+                <input index="3" source="S1_imm.0"/>
+            </fu>
+
+            <!-- ISSUE SLOT 2 -->
+            <fu type="ID" name='S2_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S2_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S2_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S2_mul' ID="S2_id_mul" config="1">
+                <input index="1" source="S2_rf.1"/>
+                <input index="2" source="S1_rf.1"/>
+                <input index="3" source="S3_rf.1"/>
+            </fu>
+
+            <fu type="ALU" name='S2_alu' ID="S2_id_alu" config="1">
+                <input index="1" source="S2_rf.1"/>
+                <input index="2" source="S2_alu.0"/>
+                <input index="3" source="S2_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S2_rf' ID="S2_id_rf">
+                <input index="0" source="S2_alu.0"/>
+                <input index="1" source="S2_mul.0"/>
+            </fu>
+
+            <!-- ISSUE SLOT 3 -->
+            <fu type="IU" name='S3_imm'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S3_id_lsu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S3_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S3_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S3_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S3_mul' ID="S3_id_mul" config="1">
+                <input index="1" source="S3_rf.1"/>
+                <input index="2" source="S2_rf.1"/>
+                <input index="3" source="S4_rf.1"/>
+            </fu>
+
+            <fu type="ALU" name='S3_alu' ID="S3_id_alu" config="1">
+                <input index="1" source="S3_rf.1"/>
+                <input index="2" source="S3_alu.0"/>
+                <input index="3" source="S3_mul.0"/>
+            </fu>
+
+            <fu type="LSU" name='S3_lsu' ID="S3_id_lsu" config="1">
+                <input index="1" source="S3_rf.1"/>
+                <input index="2" source="S3_alu.0"/>
+                <input index="3" source="S3_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S3_rf' ID="S3_id_rf">
+                <input index="0" source="S3_alu.0"/>
+                <input index="1" source="S3_mul.0"/>
+                <input index="2" source="S3_lsu.0"/>
+                <input index="3" source="S3_imm.0"/>
+            </fu>
+
+            <!-- ISSUE SLOT 4 -->
+            <fu type="ID" name='S4_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S4_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S4_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S4_mul' ID="S4_id_mul" config="1">
+                <input index="1" source="S4_rf.1"/>
+                <input index="2" source="S3_rf.1"/>
+                <input index="3" source="S5_rf.1"/>
+            </fu>
+
+            <fu type="ALU" name='S4_alu' ID="S4_id_alu" config="1">
+                <input index="1" source="S4_rf.1"/>
+                <input index="2" source="S4_alu.0"/>
+                <input index="3" source="S4_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S4_rf' ID="S4_id_rf">
+                <input index="0" source="S4_alu.0"/>
+                <input index="1" source="S4_mul.0"/>
+            </fu>
+
+            <!-- ISSUE SLOT 5 -->
+            <fu type="IU" name='S5_imm'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S5_id_lsu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S5_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S5_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S5_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S5_mul' ID="S5_id_mul" config="1">
+                <input index="1" source="S5_rf.1"/>
+                <input index="2" source="S4_rf.1"/>
+                <input index="3" source="S6_rf.1"/>
+
+            </fu>
+
+            <fu type="ALU" name='S5_alu' ID="S5_id_alu" config="1">
+                <input index="1" source="S5_rf.1"/>
+                <input index="2" source="S5_alu.0"/>
+                <input index="3" source="S5_mul.0"/>
+            </fu>
+
+            <fu type="LSU" name='S5_lsu' ID="S5_id_lsu" config="1">
+                <input index="1" source="S5_rf.1"/>
+                <input index="2" source="S5_alu.0"/>
+                <input index="3" source="S5_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S5_rf' ID="S5_id_rf">
+                <input index="0" source="S5_alu.0"/>
+                <input index="1" source="S5_mul.0"/>
+                <input index="2" source="S5_lsu.0"/>
+                <input index="3" source="S5_imm.0"/>
+            </fu>
+
+            <!-- ISSUE SLOT 6 -->
+            <fu type="ID" name='S6_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S6_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S6_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S6_mul' ID="S6_id_mul" config="1">
+                <input index="1" source="S6_rf.1"/>
+                <input index="2" source="S5_rf.1"/>
+                <input index="3" source="S7_rf.1"/>
+            </fu>
+
+            <fu type="ALU" name='S6_alu' ID="S6_id_alu" config="1">
+                <input index="1" source="S6_rf.1"/>
+                <input index="2" source="S6_alu.0"/>
+                <input index="3" source="S6_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S6_rf' ID="S6_id_rf">
+                <input index="0" source="S6_alu.0"/>
+                <input index="1" source="S6_mul.0"/>
+            </fu>
+
+            <!-- ISSUE SLOT 7 -->
+            <fu type="IU" name='S7_imm'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S7_id_lsu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S7_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S7_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S7_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S7_mul' ID="S7_id_mul" config="1">
+                <input index="1" source="S7_rf.1"/>
+                <input index="2" source="S6_rf.1"/>
+                <input index="3" source="S8_rf.1"/>
+            </fu>
+
+            <fu type="ALU" name='S7_alu' ID="S7_id_alu" config="1">
+                <input index="1" source="S7_rf.1"/>
+                <input index="2" source="S7_alu.0"/>
+                <input index="3" source="S7_mul.0"/>
+            </fu>
+
+            <fu type="LSU" name='S7_lsu' ID="S7_id_lsu" config="1">
+                <input index="1" source="S7_rf.1"/>
+                <input index="2" source="S7_alu.0"/>
+                <input index="3" source="S7_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S7_rf' ID="S7_id_rf">
+                <input index="0" source="S7_alu.0"/>
+                <input index="1" source="S7_mul.0"/>
+                <input index="2" source="S7_lsu.0"/>
+                <input index="3" source="S7_imm.0"/>
+            </fu>
+
+            <!-- ISSUE SLOT 8 -->
+            <fu type="ID" name='S8_id_mul'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S8_id_alu'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="ID" name='S8_id_rf'>
+                <input index="0" source="S1_abu.1"/>
+            </fu>
+
+            <fu type="MUL" name='S8_mul' ID="S8_id_mul" config="1">
+                <input index="1" source="S8_rf.1"/>
+                <input index="2" source="S7_rf.1"/>
+                <input index="3" source="S1_rf.1"/>
+            </fu>
+
+            <fu type="ALU" name='S8_alu' ID="S8_id_alu" config="1">
+                <input index="1" source="S8_rf.1"/>
+                <input index="2" source="S8_alu.0"/>
+                <input index="3" source="S8_mul.0"/>
+            </fu>
+
+            <fu type="RF" name='S8_rf' ID="S8_id_rf">
+                <input index="0" source="S8_alu.0"/>
+                <input index="1" source="S8_mul.0"/>
+            </fu>
+        </functionalunits>
+
+    </configuration>
+    <Core>
+        <Peripherals>
+            <Peripheral type="Console" name="CON" addr_offset="32768"/>
+        </Peripherals>
+        <Memory>
+            <GM width="32" depth="8192" addresswidth="32"/>
+        </Memory>
+    </Core>
+
+</architecture>

--- a/testsuite/systemtest/bintools/BlocksTools/tcetest_BlocksTranslator.sh
+++ b/testsuite/systemtest/bintools/BlocksTools/tcetest_BlocksTranslator.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+### TCE TESTCASE
+### title: Test BlocksTranslator tool
+### xstdout: 51, 20, 8
+
+blocks_xml=./data/generic_blocks_vliw_arch.xml
+
+blocks_translator $blocks_xml out
+
+BUSES="$(grep '<bus name.*>' out.adf | wc -l)"
+FUS="$(grep '<function-unit name.*>' out.adf | wc -l)"
+RFS="$(grep '<register-file name.*>' out.adf | wc -l)"
+echo "$BUSES, $FUS, $RFS"
+
+rm -f out.adf


### PR DESCRIPTION
Initial version of `blocks_translator` tool; Takes blocks `archiecture.xml` as input and produces `ADF` file for TCE toolset. This version supports only simple scalar version. i.e FUs with basic operations.