### PR TITLE
Blocks: Simple explorer plugin for Blocks design

### DIFF
--- a/tce/doc/man/TCE/TCE.tex
+++ b/tce/doc/man/TCE/TCE.tex
@@ -8476,6 +8476,18 @@ Example of invoking the plugin:
 \shellcmd{explore -e VLIWConnectIC -a test.adf -s 1 test.dsdb}\\
 \shellcmd{explore -w 2 test.dsdb}
 
+\subsection{Explorer Plugin: BlocksConnectIC}
+
+BlocksConnectIC takes an .ADF architecture as input, and arranges its FUs into a
+Blocks-CGRA [FPL, 2019] interconnection. The output machine has an empty bus whose
+instruction slot is used to encode long immediates. The RFs, FUs, and instructions
+are not modified by the plugin.
+
+Example of invoking the plugin:
+
+\shellcmd{explore -e BlocksConnectIC -a test.adf -s 1 test.dsdb}\\
+\shellcmd{explore -w 2 test.dsdb}
+
 \chapter{PROCESSOR TEMPLATE}
 \label{section:template}
 

--- a/tce/explorer/BlocksConnectIC.cc
+++ b/tce/explorer/BlocksConnectIC.cc
@@ -1,0 +1,270 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksConnectIC.cc (Derived from VLIWConnectIC.cc)
+ *
+ * Explorer plugin, that generates connections for Blocks machine
+ *
+ * @author Kanishkan Vadivel 2021
+ * @note rating: red
+ */
+
+#include <algorithm>
+#include <vector>
+
+#include "ControlUnit.hh"
+#include "Conversion.hh"
+#include "DSDBManager.hh"
+#include "DesignSpaceExplorerPlugin.hh"
+#include "Exception.hh"
+#include "Guard.hh"
+#include "HDBRegistry.hh"
+#include "Machine.hh"
+#include "Segment.hh"
+
+// using namespace TTAProgram;
+using namespace TTAMachine;
+using namespace HDB;
+using std::endl;
+
+class BlocksConnectIC : public DesignSpaceExplorerPlugin {
+    PLUGIN_DESCRIPTION(
+        "Arranges architecture FUs into a Blocks-like interconnection");
+
+    BlocksConnectIC() : DesignSpaceExplorerPlugin() {}
+
+    virtual bool
+    requiresStartingPointArchitecture() const {
+        return true;
+    }
+    virtual bool
+    producesArchitecture() const {
+        return true;
+    }
+    virtual bool
+    requiresHDB() const {
+        return false;
+    }
+    virtual bool
+    requiresSimulationData() const {
+        return false;
+    }
+    virtual bool
+    requiresApplication() const {
+        return false;
+    }
+
+    /**
+     *
+     * Arranges architecture FUs into a Blocks-like interconnection.
+     * This is typically as baseline for running the BusMergeMinimizer and
+     * RFPortMergeMinimizer plugins.
+     * Reference: Blocks, a reconfigurable architecture combining
+     * energy efficiency and flexibility. Wijtvliet, M. (2020).
+     * Technische Universiteit Eindhoven.
+     */
+    virtual std::vector<RowID>
+    explore(const RowID& configurationID, const unsigned int&) {
+        std::vector<RowID> result;
+
+        DSDBManager& dsdb = db();
+        DSDBManager::MachineConfiguration conf;
+        conf.hasImplementation = false;
+        TTAMachine::Machine* mach = NULL;
+
+        // load the adf from file or from dsdb
+        try {
+            conf = dsdb.configuration(configurationID);
+            mach = dsdb.architecture(conf.architectureID);
+        } catch (const Exception& e) {
+            std::ostringstream msg(std::ostringstream::out);
+            Application::errorStream()
+                << "Error loading the adf." << std::endl;
+            return result;
+        }
+        assert(mach != NULL);
+
+        // Remove unconnected sockets
+        TTAMachine::Machine::SocketNavigator socketNavi =
+            mach->socketNavigator();
+        for (int i = 0; i < socketNavi.count(); i++) {
+            if (socketNavi.item(i)->portCount() == 0) {
+                mach->removeSocket(*socketNavi.item(i));
+                i--;
+            }
+        }
+
+        // Wiping buses also destroys socket directions (input/output)
+        // and there seems to be no other way to find out whether a port
+        // is input or output.
+        // Save the directions before wiping the buses
+        for (int i = 0; i < socketNavi.count(); i++) {
+            Socket* sock = socketNavi.item(i);
+            // Restrict to 32-bit bus
+            int width = sock->port(0)->width();
+            assert(width == 32 && "ADF has Socket != 32-bit");
+        }
+
+        // save directions and sockets
+        std::vector<Socket::Direction> directions;
+        std::vector<int> readSockets, writeSockets;
+        int gcu_ra_input, gcu_ra_output, gcu_pc;
+
+        for (int i = 0; i < socketNavi.count(); i++) {
+            Socket* sock = socketNavi.item(i);
+            Socket::Direction dir = sock->direction();
+            directions.push_back(dir);
+
+            // Allow only 2-output buffers at max
+            int port_count = sock->portCount();
+            assert(
+                port_count > 0 && port_count <= 2 &&
+                "Socket is not connected or connected to more than 2 FUs");
+            // Separate GCU RA socket for special handling
+            Unit* parentUnit = sock->port(0)->parentUnit();
+            ControlUnit* gcu = dynamic_cast<ControlUnit*>(parentUnit);
+            if (dir == Socket::INPUT) {
+                if (gcu != NULL && sock->port(0)->name() == "ra") {
+                    gcu_ra_input = i;
+                } else {
+                    readSockets.push_back(i);
+                }
+            } else {
+                writeSockets.push_back(i);
+                if (gcu != NULL && sock->port(0)->name() == "ra") {
+                    gcu_ra_output = i;
+                }
+            }
+        }
+
+        // Wipe all existing buses
+        TTAMachine::Machine::BusNavigator busNavi = mach->busNavigator();
+        for (int i = 0; i < busNavi.count(); i++) {
+            mach->removeBus(*busNavi.item(i));
+            i--;
+        }
+
+        // Add new bus for each input port (i.e. We mux the 4xinput via single
+        // bus)
+        int busCount = 0;
+        std::vector<int> readBuses, writeBuses;
+
+        /* initialize random seed: */
+        std::srand(time(NULL));
+        for (unsigned int i = 0; i < readSockets.size(); i++) {
+            int rd_soc_idx = readSockets[i];
+            Socket* input_sock = socketNavi.item(rd_soc_idx);
+
+            // Attach 32-bit bus segment
+            TTAMachine::Segment* newSegment = createBus(mach, 32);
+            newSegment->attachSocket(*input_sock);
+            input_sock->setDirection(directions[rd_soc_idx]);
+            // Handle special case for GCU
+            Unit* parentUnit = input_sock->port(0)->parentUnit();
+            if (dynamic_cast<ControlUnit*>(parentUnit) != NULL &&
+                input_sock->port(0)->name() == "pc") {
+                Socket* ra_sock = socketNavi.item(gcu_ra_input);
+                newSegment->attachSocket(*ra_sock);
+                ra_sock->setDirection(directions[gcu_ra_input]);
+                gcu_pc = rd_soc_idx;
+            }
+            readBuses.push_back(busCount++);
+
+            // Make connections to the socket (maximum 4 connections)
+            int output_socket_count = writeSockets.size();
+            int req_connections = std::min(output_socket_count, 4);
+            while (req_connections > 0) {
+                // Select random FU output port
+                int wr_soc_idx =
+                    writeSockets[std::rand() % writeSockets.size()];
+                Socket* output_sock = socketNavi.item(wr_soc_idx);
+
+                // Check if we already have connections
+                if (newSegment->isConnectedTo(*output_sock)) {
+                    continue;
+                }
+
+                // No connections to this port yet; make connection
+                newSegment->attachSocket(*output_sock);
+                output_sock->setDirection(directions[wr_soc_idx]);
+                req_connections--;
+            }
+        }
+
+        // Create instruction template for imm unit
+        if (mach->immediateUnitNavigator().count() != 0) {
+            ImmediateUnit* immu = mach->immediateUnitNavigator().item(0);
+
+            while (mach->instructionTemplateNavigator().count() > 0) {
+                mach->deleteInstructionTemplate(
+                    *mach->instructionTemplateNavigator().item(0));
+            }
+
+            new InstructionTemplate("no_limm", *mach);
+
+            InstructionTemplate* limm =
+                new InstructionTemplate("limm", *mach);
+            TTAMachine::Segment* newSegment = createBus(mach, 32);
+            Bus* newBus = newSegment->parentBus();
+
+            limm->addSlot(newBus->name(), 32, *immu);
+
+            // Attch GCU's RA and PC sockets (We do not have explicit RA port
+            // in Blocks; so, this is just to emulate the effect of single
+            // port.)
+            newSegment->attachSocket(*socketNavi.item(gcu_ra_input));
+            newSegment->attachSocket(*socketNavi.item(gcu_ra_output));
+            newSegment->attachSocket(*socketNavi.item(gcu_pc));
+        }
+
+        // add machine to configuration
+        conf.architectureID = dsdb.addArchitecture(*mach);
+
+        // add new configuration to dsdb
+        RowID confID = dsdb.addConfiguration(conf);
+        result.push_back(confID);
+        return result;
+    }
+
+protected:
+    /**
+     * Creates a bus with specified bit width.
+     *
+     * @param mach Machine for that bus.
+     * @param width Bit width of a bus.
+     * @return Bus segment.
+     */
+    TTAMachine::Segment*
+    createBus(TTAMachine::Machine* mach, int width) {
+        int idx = mach->busNavigator().count();
+        TCEString busName = "B" + Conversion::toString(idx);
+        Bus* newBus = new Bus(busName, width, 0, Machine::SIGN);
+        TTAMachine::Segment* newSegment =
+            new TTAMachine::Segment(busName, *newBus);
+        mach->addBus(*newBus);
+        return newSegment;
+    }
+};
+
+EXPORT_DESIGN_SPACE_EXPLORER_PLUGIN(BlocksConnectIC)

--- a/tce/explorer/Makefile.am
+++ b/tce/explorer/Makefile.am
@@ -5,7 +5,8 @@ pkglib_LTLIBRARIES = \
 	GrowMachine.la ImmediateGenerator.la \
 	ImplementationSelector.la ComponentAdder.la \
 	Evaluate.la MinimalOpSet.la ConnectionSweeper.la \
-	ADFCombiner.la VectorLSGenerator.la VLIWConnectIC.la
+	ADFCombiner.la VectorLSGenerator.la VLIWConnectIC.la \
+	BlocksConnectIC.la
 
 # Libtool seems to realize we are compiling from .cc instead of .c
 # just by defining the first source. Without this it fails.
@@ -23,6 +24,7 @@ ConnectionSweeper_la_SOURCES = ConnectionSweeper.cc
 ADFCombiner_la_SOURCES = ADFCombiner.cc
 VectorLSGenerator_la_SOURCES = VectorLSGenerator.cc
 VLIWConnectIC_la_SOURCES = VLIWConnectIC.cc
+BlocksConnectIC_la_SOURCES = BlocksConnectIC.cc
 
 PROJECT_ROOT = $(top_srcdir)
 SRC_ROOT_DIR = ${PROJECT_ROOT}/src

--- a/tce/src/procgen/ProDe/BlocksConnectICCmd.cc
+++ b/tce/src/procgen/ProDe/BlocksConnectICCmd.cc
@@ -1,0 +1,154 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksConnectICCmd.cc
+ *
+ * Definition of BlocksConnectICCmd class. (Derived from VLIWConnectICCmd.cc)
+ *
+ * @author Kanishkan Vadivel 2021 (k.vadivel-no.spam-tue.nl)
+ * @note rating: red
+ */
+
+#include "BlocksConnectICCmd.hh"
+
+#include <wx/docview.h>
+
+#include <string>
+
+#include "DSDBManager.hh"
+#include "DesignSpaceExplorerPlugin.hh"
+#include "FileSystem.hh"
+#include "MDFDocument.hh"
+#include "Machine.hh"
+#include "Model.hh"
+#include "ProDe.hh"
+#include "ProDeConstants.hh"
+
+using namespace TTAMachine;
+
+BlocksConnectICCmd::BlocksConnectICCmd()
+    : EditorCommand(ProDeConstants::CMD_NAME_BLOCKS_CONNECT_IC) {}
+
+BlocksConnectICCmd::~BlocksConnectICCmd() {}
+
+/**
+ * Executes the command.
+ *
+ * @return True, if the command was succesfully executed, false otherwise.
+ */
+bool
+BlocksConnectICCmd::Do() {
+    assert(view() != NULL);
+
+    TTAMachine::Machine* machine =
+        dynamic_cast<MDFDocument*>(view()->GetDocument())
+            ->getModel()
+            ->getMachine();
+
+    Model* model =
+        dynamic_cast<MDFDocument*>(view()->GetDocument())->getModel();
+
+    model->pushToStack();
+
+    // open up a temporary dsdb
+    const std::string dsdbFile = "tmp.dsdb";
+    FileSystem::removeFileOrDirectory(dsdbFile);
+    DSDBManager* dsdb = DSDBManager::createNew(dsdbFile);
+    RowID archID = dsdb->addArchitecture(*machine);
+
+    DSDBManager::MachineConfiguration confIn(archID, false, ILLEGAL_ROW_ID);
+    RowID confID = dsdb->addConfiguration(confIn);
+
+    // load BlocksConnectIC explorer plugin
+    DesignSpaceExplorer explorer;
+    DesignSpaceExplorerPlugin* plugin =
+        explorer.loadExplorerPlugin("BlocksConnectIC", dsdb);
+    plugin->setDSDB(*dsdb);
+
+    try {
+        std::vector<RowID> result = plugin->explore(confID, 0);
+        // store the new machine
+        TTAMachine::Machine& newMachine =
+            *dsdb->architecture(confID + result.size());
+        machine->copyFromMachine(newMachine);
+    } catch (Exception e) {
+        std::cerr << "Could not create Blocks Connect IC" << std::endl;
+        FileSystem::removeFileOrDirectory(dsdbFile);
+        model->popFromStack();
+        return false;
+    }
+    FileSystem::removeFileOrDirectory(dsdbFile);
+    model->notifyObservers();
+
+    return true;
+}
+
+/**
+ * Returns id of this command.
+ */
+int
+BlocksConnectICCmd::id() const {
+    return ProDeConstants::COMMAND_BLOCKS_CONNECT_IC;
+}
+
+/**
+ * Creates and returns a new instance of this command.
+ */
+BlocksConnectICCmd*
+BlocksConnectICCmd::create() const {
+    return new BlocksConnectICCmd();
+}
+
+/**
+ * Returns short version of the command name.
+ */
+std::string
+BlocksConnectICCmd::shortName() const {
+    return ProDeConstants::CMD_SNAME_BLOCKS_CONNECT_IC;
+}
+
+/**
+ * Returns true when the command is executable, false when not.
+ *
+ * This command is executable when a document is open.
+ *
+ * @return True, if a document is open.
+ */
+bool
+BlocksConnectICCmd::isEnabled() {
+    wxDocManager* manager = wxGetApp().docManager();
+    wxView* view = manager->GetCurrentView();
+
+    if (view == NULL) {
+        return false;
+    }
+
+    Model* model =
+        dynamic_cast<MDFDocument*>(view->GetDocument())->getModel();
+
+    if (model == NULL) {
+        return false;
+    }
+    return true;
+}

--- a/tce/src/procgen/ProDe/BlocksConnectICCmd.hh
+++ b/tce/src/procgen/ProDe/BlocksConnectICCmd.hh
@@ -1,0 +1,52 @@
+/*
+    Copyright (c) 2002-2021 Tampere University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * @file BlocksConnectICCmd.hh
+ *
+ * Declaration of BlocksConnectICCmd class. (Derived from VLIWConnectICCmd.hh)
+ *
+ * @author Kanishkan Vadivel 2021 (k.vadivel-no.spam-tue.nl)
+ * @note rating: red
+ */
+
+#ifndef TTA_BLOCKS_CONNECT_IC_CMD_HH
+#define TTA_BLOCKS_CONNECT_IC_CMD_HH
+
+#include "EditorCommand.hh"
+
+/**
+ * Command for calling BlocksConnectIC explorer plugin.
+ */
+class BlocksConnectICCmd : public EditorCommand {
+public:
+    BlocksConnectICCmd();
+    virtual ~BlocksConnectICCmd();
+    virtual bool Do();
+    virtual int id() const;
+    virtual BlocksConnectICCmd* create() const;
+    virtual bool isEnabled();
+    virtual std::string shortName() const;
+};
+
+#endif

--- a/tce/src/procgen/ProDe/MainFrame.cc
+++ b/tce/src/procgen/ProDe/MainFrame.cc
@@ -30,7 +30,6 @@
  * @note rating: red
  */
 
-
 #include <wx/sizer.h>
 #include <wx/statusbr.h>
 
@@ -88,6 +87,7 @@
 #include "ToggleUnitDetailsCmd.hh"
 #include "EditMachineCmd.hh"
 #include "VLIWConnectICCmd.hh"
+#include "BlocksConnectICCmd.hh"
 
 #include "KeyboardShortcut.hh"
 #include "ProDeOptions.hh"
@@ -175,6 +175,7 @@ MainFrame::MainFrame(
     commandRegistry_->addCommand(new UserManualCmd());
     commandRegistry_->addCommand(new AboutCmd());
     commandRegistry_->addCommand(new VLIWConnectICCmd());
+    commandRegistry_->addCommand(new BlocksConnectICCmd());
 
     toolbar_ = NULL;
     CreateStatusBar(2);
@@ -653,6 +654,11 @@ MainFrame::createMenubar() {
         ProDeConstants::COMMAND_VLIW_CONNECT_IC,
         menuAccelerator(ProDeConstants::COMMAND_VLIW_CONNECT_IC).Prepend(
             _T("&VLIW Connect IC")));
+
+    toolMenu->Append(
+        ProDeConstants::COMMAND_BLOCKS_CONNECT_IC,
+        menuAccelerator(ProDeConstants::COMMAND_BLOCKS_CONNECT_IC)
+            .Prepend(_T("&Blocks Connect IC")));
 
     toolMenu->Append(
         ProDeConstants::COMMAND_VERIFY_MACHINE,

--- a/tce/src/procgen/ProDe/Makefile.am
+++ b/tce/src/procgen/ProDe/Makefile.am
@@ -111,7 +111,8 @@ prode_SOURCES = Model.cc\
 		  GenerateProcessorDialog.cc OpsetDialog.cc \
 		  CallExplorerPlugin.cc CallExplorerPluginCmd.cc \
 		  EditParameterDialog.cc AutoSelectImplementationsDialog.cc \
-		  MachineDialog.cc EditMachineCmd.cc VLIWConnectICCmd.cc
+		  MachineDialog.cc EditMachineCmd.cc VLIWConnectICCmd.cc \
+		  BlocksConnectICCmd.cc
 
 prode_LDFLAGS = $(TCE_LDFLAGS)
 
@@ -239,5 +240,6 @@ prode_SOURCES += \
 	ModifyRFCmd.hh AddASCmd.hh \
 	ProDeRFEditPolicy.hh PasteComponentCmd.icc \
 	MDFView.icc AutoSelectImplementationsDialog.hh \
-	MachineDialog.hh EditMachineCmd.hh VLIWConnectICCmd.hh
+	MachineDialog.hh EditMachineCmd.hh VLIWConnectICCmd.hh \
+	BlocksConnectICCmd.hh
 ## headers end

--- a/tce/src/procgen/ProDe/ProDeConstants.cc
+++ b/tce/src/procgen/ProDe/ProDeConstants.cc
@@ -109,6 +109,7 @@ const string ProDeConstants::CMD_NAME_FULLY_CONNECT_BUSSES =
     "Fully Connect IC";
 const string ProDeConstants::CMD_NAME_VLIW_CONNECT_IC =
     "VLIW Connect IC";
+const string ProDeConstants::CMD_NAME_BLOCKS_CONNECT_IC = "Blocks Connect IC";
 const string ProDeConstants::CMD_NAME_EDIT_MACHINE =
     "Processor Configurations";
 
@@ -165,6 +166,7 @@ const string ProDeConstants::CMD_SNAME_EDIT_BUS_ORDER = "Bus Ord.";
 const string ProDeConstants::CMD_SNAME_EDIT_CONNECTIONS = "Connect";
 const string ProDeConstants::CMD_SNAME_FULLY_CONNECT_BUSSES = "Full IC";
 const string ProDeConstants::CMD_SNAME_VLIW_CONNECT_IC = "VLIW IC";
+const string ProDeConstants::CMD_SNAME_BLOCKS_CONNECT_IC = "Blocks IC";
 const string ProDeConstants::CMD_SNAME_VERIFY_MACHINE = "Verify";
 const string ProDeConstants::CMD_SNAME_IMPLEMENTATION = "Implement";
 const string ProDeConstants::CMD_SNAME_EXPLORER_PLUGIN = "Explorer";

--- a/tce/src/procgen/ProDe/ProDeConstants.hh
+++ b/tce/src/procgen/ProDe/ProDeConstants.hh
@@ -145,6 +145,8 @@ public:
     static const std::string CMD_NAME_FULLY_CONNECT_BUSSES;
     /// Command name for the "VLIW Connect IC" command.
     static const std::string CMD_NAME_VLIW_CONNECT_IC;
+    /// Command name for the "Blcoks Connect IC" command.
+    static const std::string CMD_NAME_BLOCKS_CONNECT_IC;
     /// Command name for the "Processor configurations" command.
     static const std::string CMD_NAME_EDIT_MACHINE;
 
@@ -237,6 +239,8 @@ public:
     static const std::string CMD_SNAME_FULLY_CONNECT_BUSSES;
     /// Command name for the "VLIW Connect IC" command.
     static const std::string CMD_SNAME_VLIW_CONNECT_IC;
+    /// Command name for the "Blocks Connect IC" command.
+    static const std::string CMD_SNAME_BLOCKS_CONNECT_IC;
     /// Command name for the "Verify Machine" command.
     static const std::string CMD_SNAME_VERIFY_MACHINE;
     /// Command name for the "Processor Implementation" command.
@@ -442,6 +446,7 @@ public:
 
             COMMAND_FULLY_CONNECT_BUSSES,
             COMMAND_VLIW_CONNECT_IC,
+            COMMAND_BLOCKS_CONNECT_IC,
             COMMAND_VERIFY_MACHINE,
             COMMAND_IMPLEMENTATION,
             COMMAND_CALL_EXPLORER_PLUGIN,

--- a/testsuite/systemtest/bintools/BlocksTools/data/blocks_base.adf
+++ b/testsuite/systemtest/bintools/BlocksTools/data/blocks_base.adf
@@ -1,0 +1,1357 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<adf version="1.10">
+
+  <little-endian/>
+
+  <bus name="ra_out_to_ra_in">
+    <width>32</width>
+    <segment name="seg1">
+      <writes-to/>
+    </segment>
+    <short-immediate>
+      <extension>zero</extension>
+      <width>0</width>
+    </short-immediate>
+  </bus>
+
+  <bus name="bus_1">
+    <width>32</width>
+    <segment name="seg1">
+      <writes-to/>
+    </segment>
+    <short-immediate>
+      <extension>zero</extension>
+      <width>0</width>
+    </short-immediate>
+  </bus>
+
+  <socket name="raIn">
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="abu_out0">
+    <writes-to>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </writes-to>
+    <writes-to>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="value">
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="pc">
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="lsu_in1t">
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="lsu_in2">
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="lsu_out0">
+    <writes-to>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+    <writes-to>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="lsu_out1">
+    <writes-to>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+    <writes-to>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="alu_in1t">
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="alu_in2">
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="alu_out0">
+    <writes-to>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+    <writes-to>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="alu_out1">
+    <writes-to>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+    <writes-to>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="rf_in1t">
+    <reads-from>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </reads-from>
+    <reads-from>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="rf_out1">
+    <writes-to>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+    <writes-to>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="imm_out0">
+    <writes-to>
+      <bus>bus_1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+    <writes-to>
+      <bus>ra_out_to_ra_in</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <function-unit name="lsu_out0">
+    <port name="in1t">
+      <connects-to>lsu_in1t</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+      <no-register/>
+    </port>
+    <port name="in2">
+      <connects-to>lsu_in2</connects-to>
+      <width>32</width>
+      <no-register/>
+    </port>
+    <port name="out0">
+      <connects-to>lsu_out0</connects-to>
+      <width>32</width>
+    </port>
+    <operation>
+      <name>ld32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ldu16</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ldu8</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st16</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st8</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>copy</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <address-space>data</address-space>
+  </function-unit>
+
+  <function-unit name="lsu_out1">
+    <port name="in1t">
+      <connects-to>lsu_in1t</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+      <no-register/>
+    </port>
+    <port name="in2">
+      <connects-to>lsu_in2</connects-to>
+      <width>32</width>
+      <no-register/>
+    </port>
+    <port name="out1">
+      <connects-to>lsu_out1</connects-to>
+      <width>32</width>
+    </port>
+    <operation>
+      <name>ld32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ldu16</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ldu8</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st16</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st8</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>copy</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <address-space>data</address-space>
+  </function-unit>
+
+  <function-unit name="alu_out0">
+    <port name="in1t">
+      <connects-to>alu_in1t</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+      <no-register/>
+    </port>
+    <port name="in2">
+      <connects-to>alu_in2</connects-to>
+      <width>32</width>
+      <no-register/>
+    </port>
+    <port name="out0">
+      <connects-to>alu_out0</connects-to>
+      <width>32</width>
+    </port>
+    <operation>
+      <name>add</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>and</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>eq</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ge</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>geu</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>gt</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>gtu</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ior</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>lt</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ltu</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ne</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>not</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shl1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shl4_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shr1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shr4_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shru1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shru4_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>sub</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>xor</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>copy</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out0</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <address-space/>
+  </function-unit>
+
+  <function-unit name="alu_out1">
+    <port name="in1t">
+      <connects-to>alu_in1t</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+      <no-register/>
+    </port>
+    <port name="in2">
+      <connects-to>alu_in2</connects-to>
+      <width>32</width>
+      <no-register/>
+    </port>
+    <port name="out1">
+      <connects-to>alu_out1</connects-to>
+      <width>32</width>
+    </port>
+    <operation>
+      <name>add</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>and</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>eq</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ge</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>geu</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>gt</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>gtu</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ior</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>lt</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ltu</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ne</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>not</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shl1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shl4_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shr1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shr4_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shru1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shru4_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>sub</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>xor</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>copy</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <address-space/>
+  </function-unit>
+
+  <register-file name="rf">
+    <type>normal</type>
+    <size>16</size>
+    <width>32</width>
+    <max-reads>1</max-reads>
+    <max-writes>1</max-writes>
+    <port name="in1">
+      <connects-to>rf_in1t</connects-to>
+    </port>
+    <port name="out1">
+      <connects-to>rf_out1</connects-to>
+    </port>
+  </register-file>
+
+  <address-space name="data">
+    <width>8</width>
+    <min-address>0</min-address>
+    <max-address>32768</max-address>
+  </address-space>
+
+  <address-space name="instructions">
+    <width>8</width>
+    <min-address>0</min-address>
+    <max-address>2046</max-address>
+  </address-space>
+
+  <global-control-unit name="abu">
+    <port name="pc">
+      <connects-to>pc</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+      <no-register/>
+    </port>
+    <port name="value">
+      <connects-to>value</connects-to>
+      <width>32</width>
+      <no-register/>
+    </port>
+    <special-port name="ra">
+      <connects-to>raIn</connects-to>
+      <connects-to>abu_out0</connects-to>
+      <width>32</width>
+    </special-port>
+    <return-address>ra</return-address>
+    <ctrl-operation>
+      <name>bnz</name>
+      <bind name="1">value</bind>
+      <bind name="2">pc</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </ctrl-operation>
+    <ctrl-operation>
+      <name>bz</name>
+      <bind name="1">value</bind>
+      <bind name="2">pc</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </ctrl-operation>
+    <ctrl-operation>
+      <name>call</name>
+      <bind name="1">pc</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </ctrl-operation>
+    <ctrl-operation>
+      <name>jump</name>
+      <bind name="1">pc</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </ctrl-operation>
+    <address-space>instructions</address-space>
+    <delay-slots>2</delay-slots>
+    <guard-latency>1</guard-latency>
+  </global-control-unit>
+
+  <immediate-unit name="imm">
+    <type>normal</type>
+    <size>1</size>
+    <width>32</width>
+    <max-reads>1</max-reads>
+    <max-writes>1</max-writes>
+    <guard-latency>1</guard-latency>
+    <extension>zero</extension>
+    <port name="out0">
+      <connects-to>imm_out0</connects-to>
+    </port>
+    <template name="no_limm"/>
+  </immediate-unit>
+
+</adf>

--- a/testsuite/systemtest/bintools/BlocksTools/tcetest_BlocksConnectIC.sh
+++ b/testsuite/systemtest/bintools/BlocksTools/tcetest_BlocksConnectIC.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+### TCE TESTCASE 
+### title: Create BlocksConnectIC ADF via plugin
+### xstdout: 8, 4, 1
+
+mach=data/blocks_base.adf
+
+explore -e BlocksConnectIC -a $mach -s 1 testdb.dsdb 1>/dev/null
+explore -w 2 testdb.dsdb 1>/dev/null
+
+BUSES="$(grep '<bus name.*>' 2.adf | wc -l)"
+FUS="$(grep '<function-unit name.*>' 2.adf | wc -l)"
+RFS="$(grep '<register-file name.*>' 2.adf | wc -l)"
+echo "$BUSES, $FUS, $RFS"
+
+rm -f testdb.dsdb 2.adf


### PR DESCRIPTION
Provides Blocks CGRA design support. Similar to VLIWConnectIC plugin, the BlocksConnectIC plugin is added to the GUI of ProDe and Explorer framework.
- The proposed plugin enforces connectivity requirements of Blocks architecture. i.e. It Modifies the IC network of given ADF to Blocks-Interconnect.
-  Resources (FU, RF, IMM, Memory) are not touched by the plugin
- Current support is limited to 32-bit Blocks IC design