### PR TITLE
hwloop: Inital llvm hwloop support

### DIFF
--- a/tce/CHANGES
+++ b/tce/CHANGES
@@ -10,6 +10,8 @@ Notable changes and features
   assembly constructs such as local register variables and clobbers
   in C code. Consequently, this enables clobber and physical register
   constraints in LLVM IR.
+- Experimental hardware loop compiler support based on LLVM's generic
+  hardware loop pass.
 
 Notable bugfixes
 ----------------------------

--- a/tce/doc/announcements/1.25.txt
+++ b/tce/doc/announcements/1.25.txt
@@ -40,6 +40,9 @@ Czech Republic, Finland, Spain, Italy. It was also supported by European
 Union's Horizon 2020 research and innovation programme under Grant Agreement
 No 871738 (CPSoSaware).
 
+The contributions of this release were supported in part by Eindhoven University
+of Technology (TU/e) under the Dutch NWO project ZERO (P15-06 project 5).
+
 Links
 =====
 

--- a/tce/doc/man/TCE/TCE.tex
+++ b/tce/doc/man/TCE/TCE.tex
@@ -3502,6 +3502,73 @@ You can now select \textit{Flow>Generate Bitstream} from the menu bar. This will
 run the design through synthesis and implementation, and give you a bitstream
 file with which you can program the FPGA fabric on your SoC.
 
+\section{Hardware Loops}
+\label{section:hwloops}
+
+This section explains the usage of hardware loop operations in TCE. The design
+is based on the LLVM's generic hardware loop support (Hardware Loops pass)
+and its purpose is to provide enhancements to the program control unit in
+TTA by effectively handling loop control-flow (loop index update and conditional
+branch to loop-entry).
+
+TCE's implementation of hardware loops lowers the LLVM's hardware loop
+intrinsics to a backend instruction HWLOOP in the loop pre-header. The
+HWLOOP instruction takes two parameters
+\begin{itemize}
+\item \textbf{Iteration count} - Specifies the number of times the loop-body
+    need to be iterated
+\item \textbf{Instruction count} - Number instructions in the loop-body
+\end{itemize}
+
+Note that, the HWLOOP instruction is handled by the control hardware. Other
+details such as whether and how the loop is cached is left to the underlying
+hardware implementation.
+
+\subsection{Tour to Using the Hardware Loops}
+The hardware loop can be enabled in the TCE by simply adding HWLOOP
+instructions to control-unit in the TTA design. To start with, \textbf{copy
+minimalist TTA machine by}:
+
+\shellcmd{cp \$(tce-config -{}-prefix)/share/tce/data/mach/minimal.adf hwloop.adf}
+
+We can observe from OSED that the HWLOOP instruction takes two parameters.
+Hence, add an additional input port to the control-unit and add then the
+HWLOOP instruction to the unit.
+
+Next, we create a program that uses the added hardware loop instruction
+and simulate it in the TTA simulator. \textbf{Create a new file named as
+``example.c''}. In the below, is example program that can use the hardware
+loops.
+
+\begin{verbatim}
+#define SAMPLE_SIZE 128
+volatile int input[SAMPLE_SIZE];
+
+int main() {
+    // Simple memset kernel
+    #pragma clang loop unroll(disable)
+    for (int i=0; i<SAMPLE_SIZE; i++) {
+        input[i] = 0;
+    }
+    return 0;
+}
+\end{verbatim}
+
+\textbf{Copy-paste the code to the newly created file and compile it to TPEF} by
+
+\shellcmd{tcecc -O3 -o example.tpef -a hwloop.adf example.c}
+
+Next, to see  how the hardware loop works,  \textbf{simulate the program
+  in TTA simulator ProXim} by:
+
+\shellcmd{proxim hwloop.adf example.tpef}
+
+After triggering the hardware loop operation HWLOOP, there are delay
+slot instructions,  which are  always executed before the  actual loop.
+The number  of delay slots is  defined in the control  unit of  the ADF.
+Stepping  through the  program we  should observe that the loop in the
+above source  code is repeated by 128 times before exiting the  loop.
+
 \chapter{PROCESSOR DESIGN TOOLS}
 \label{chapter:procgen}
 

--- a/tce/opset/base/base.opp
+++ b/tce/opset/base/base.opp
@@ -4341,4 +4341,17 @@ Input operand is discarded.</description>
     <in element-count="1" element-width="1" id="1" type="RawData"/>
   </operation>
 
+  <operation>
+    <name>HWLOOP</name>
+    <description>Hardware-loop instruction to iterate given number of instruction. Operand-1: Iteration count and Operand-2: Number of instructions.
+        The instruction only guarantees the loop-iterations. Insturction cache behaviour (eg: Loop bufffers) are left to hardware to handle.
+    </description>
+    <inputs>2</inputs>
+    <outputs>0</outputs>
+    <side-effects/>
+    <control-flow/>
+    <in element-count="1" element-width="32" id="1" type="UIntWord"/>
+    <in element-count="1" element-width="32" id="2" type="UIntWord"/>
+  </operation>
+
 </osal>

--- a/tce/src/applibs/LLVMBackend/LLVMTCECmdLineOptions.cc
+++ b/tce/src/applibs/LLVMBackend/LLVMTCECmdLineOptions.cc
@@ -83,6 +83,9 @@ const std::string LLVMTCECmdLineOptions::USAGE =
 const std::string LLVMTCECmdLineOptions::SWL_GEN_PLUGIN_ONLY =
     "gen-plugin-only";
 
+const std::string LLVMTCECmdLineOptions::SWL_DISABLE_HWLOOPS =
+    "disable-hwloops";
+
 const std::string LLVMTCECmdLineOptions::SWL_ASSUME_ADF_STACKALIGNMENT =
     "assume-adf-stackalignment";
 /**
@@ -216,6 +219,10 @@ LLVMTCECmdLineOptions::LLVMTCECmdLineOptions() {
             "Generates LLVM backend plugin for target machine without tpef "
             "generation."));
 
+    addOption(new BoolCmdLineOptionParser(
+        SWL_DISABLE_HWLOOPS,
+        "Do not use hardware loops even though the processor supports them."));
+
     addOption(
 	new BoolCmdLineOptionParser(
             SWL_ASSUME_ADF_STACKALIGNMENT,
@@ -335,7 +342,7 @@ LLVMTCECmdLineOptions::getLLVMargv() const {
     if (!findOption(LLVM_USER_ARGS)->isDefined()) {
         return "llvm-tce --no-stack-coloring";
     } else {
-        std::string argv = "llvm-tce --no-stack-coloring" +
+        std::string argv = "llvm-tce --no-stack-coloring " +
                            findOption(LLVM_USER_ARGS)->String();
         return argv;
     }
@@ -429,6 +436,12 @@ LLVMTCECmdLineOptions::generatePluginOnly() const {
     return (findOption(SWL_GEN_PLUGIN_ONLY)->isDefined() &&
         findOption(SWL_GEN_PLUGIN_ONLY)->isFlagOn());
 }
+
+bool
+LLVMTCECmdLineOptions::disableHWLoops() const {
+    return findOption(SWL_DISABLE_HWLOOPS)->isDefined();
+}
+
 bool
 LLVMTCECmdLineOptions::assumeADFStackAlignment() const {
     return findOption(SWL_ASSUME_ADF_STACKALIGNMENT)->isDefined();

--- a/tce/src/applibs/LLVMBackend/LLVMTCECmdLineOptions.hh
+++ b/tce/src/applibs/LLVMBackend/LLVMTCECmdLineOptions.hh
@@ -98,6 +98,7 @@ public:
     bool printInlineAsmWarnings() const;
     bool generatePluginOnly() const;
     bool disableAddressSpaceAA() const;
+    bool disableHWLoops() const;
     bool assumeADFStackAlignment() const;
 
     virtual void printVersion() const {
@@ -140,6 +141,7 @@ private:
     static const std::string USAGE;
     static const std::string SWL_PRINT_INLINE_ASM_WARNINGS;
     static const std::string SWL_GEN_PLUGIN_ONLY;
+    static const std::string SWL_DISABLE_HWLOOPS;
     static const std::string SWL_ASSUME_ADF_STACKALIGNMENT;
 };
 

--- a/tce/src/applibs/LLVMBackend/TCETargetMachine.cc
+++ b/tce/src/applibs/LLVMBackend/TCETargetMachine.cc
@@ -269,6 +269,13 @@ TCEPassConfig::addPreRegAlloc() {
 
 bool
 TCEPassConfig::addPreISel() {
+    LLVMTCECmdLineOptions* options =
+        dynamic_cast<LLVMTCECmdLineOptions*>(Application::cmdLineOptions());
+    if (options != NULL && !options->disableHWLoops() &&
+        ((static_cast<TCETargetMachine*>(TM))->ttaMach_)
+            ->hasOperation("hwloop"))
+        addPass(createHardwareLoopsPass());
+
     // lower floating point stuff.. maybe could use plugin as param instead machine...    
     addPass(createLowerMissingInstructionsPass(
                 *((static_cast<TCETargetMachine*>(TM))->ttaMach_)));

--- a/tce/src/applibs/LLVMBackend/TDGen.hh
+++ b/tce/src/applibs/LLVMBackend/TDGen.hh
@@ -274,6 +274,7 @@ protected:
     void writeControlFlowInstrDefs(std::ostream& os);
     void writeCondBranchDefs(std::ostream& os);
     void writeCallDef(std::ostream& o);
+    void writeHWLoopDef(std::ostream& o);
     virtual void writeCallDefRegs(std::ostream& o);
 
     void writeRegisterClasses(std::ostream& o);

--- a/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.hh
+++ b/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.hh
@@ -127,6 +127,7 @@ namespace llvm {
         SDValue LowerShift(SDValue op, SelectionDAG& dag) const;
         SDValue LowerBuildBooleanVectorVector(
             SDValue Op, MVT newElementVT, int elemCount, SelectionDAG &DAG) const;
+        SDValue lowerHWLoops(SDValue op, SelectionDAG &dag) const;
 
         SDValue lowerExtOrBoolLoad(SDValue op, SelectionDAG& DAG) const;
 

--- a/tce/src/applibs/Scheduler/Algorithms/BBSchedulerController.cc
+++ b/tce/src/applibs/Scheduler/Algorithms/BBSchedulerController.cc
@@ -525,6 +525,10 @@ BBSchedulerController::executeDDGPass(
 
     try {
         ddgPasses[fastest]->handleDDG(*ddg, *rm, targetMachine, minCycle);
+        if (bb.tripCount()) {
+            bbn->predecessor()->updateHWloopLength(
+                ddg->largestCycle() + 1 - ddg->smallestCycle());
+        }
     } catch (const Exception &e) {
         debugLog(e.errorMessageStack());
         abortWithError("Scheduling failed!");

--- a/tce/src/applibs/Scheduler/ProgramRepresentations/CFG/BasicBlockNode.hh
+++ b/tce/src/applibs/Scheduler/ProgramRepresentations/CFG/BasicBlockNode.hh
@@ -94,6 +94,7 @@ public:
     void setScheduled(bool state=true) { scheduled_ = state;}
 
     std::pair<TTAProgram::Move*,TTAProgram::Move*> findJumps();
+    void updateHWloopLength(unsigned len);
 
     void updateReferencesFromProcToCfg(TTAProgram::Program& prog);
 

--- a/tce/src/base/program/Instruction.cc
+++ b/tce/src/base/program/Instruction.cc
@@ -469,7 +469,12 @@ Instruction::hasReturn() const {
  */
 bool
 Instruction::hasControlFlowMove() const {
-    return hasJump() || hasCall();
+    for (int i = 0; i < moveCount(); i++) {
+        if (move(i).isControlFlowMove()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 

--- a/tce/src/bintools/Compiler/llvm-tce/LLVMTCE.cc
+++ b/tce/src/bintools/Compiler/llvm-tce/LLVMTCE.cc
@@ -170,9 +170,25 @@ main(int argc, char* argv[]) {
     // ---- Run compiler ----
     try {
         InterPassData* ipData = new InterPassData;
-
-        const char* argv[] = {"llvm-tce", "--no-stack-coloring"};
-        llvm::cl::ParseCommandLineOptions(2, argv, "llvm linker\n");
+        int argc = 0;
+        std::string argv = options->getLLVMargv();
+        if (options->isVerboseSpamSwitchDefined()) {
+            std::cout << "llvm args = " << argv << std::endl;
+        }
+        // Convert to char**
+        std::vector<char*> argv_array;
+        std::istringstream iss(argv);
+        std::string token;
+        while (iss >> token) {
+            char* arg = new char[token.size() + 1];
+            copy(token.begin(), token.end(), arg);
+            arg[token.size()] = '\0';
+            argv_array.push_back(arg);
+            argc++;
+        }
+        argv_array.push_back(0);
+        llvm::cl::ParseCommandLineOptions(
+            argc, argv_array.data(), "llvm flags\n");
 
         LLVMBackend compiler(useInstalledVersion, options->tempDir());
         TTAProgram::Program* seqProg =

--- a/tce/src/bintools/Compiler/tcecc.in
+++ b/tce/src/bintools/Compiler/tcecc.in
@@ -1144,6 +1144,9 @@ p.add_option('--version', action='store_true',
 p.add_option('--llvm-args', type="string",
              action='store', dest='llvm_args', default="",
              help="""Arguments passed to LLVM.""")
+p.add_option('--disable-llvm-hwloop',
+             action='store_true', dest='disable_llvm_hwloop', default=False,
+             help="""Disable LLVM hwloop pass.""")
 
 p.add_option('--dump-ddgs-dot', action='store_true', dest='dump_ddgs_dot', default=False,
              help=\
@@ -1751,6 +1754,11 @@ if options.adf_file != "":
 
     if options.dump_ifc_cfgs:
         command += " --dump-ifconversion-cfgs"
+
+    if options.disable_llvm_hwloop:
+        command += " --disable-hwloops"
+    else:
+        options.llvm_args += " -force-hardware-loops -hardware-loop-decrement=1 -hardware-loop-counter-bitwidth=32"
 
     if options.llvm_args != "":
         command += " --llvm-args=\"" + options.llvm_args + "\""

--- a/testsuite/systemtest/bintools/Compiler/data/hwloop.c
+++ b/testsuite/systemtest/bintools/Compiler/data/hwloop.c
@@ -1,0 +1,62 @@
+#define SAMPLE_SIZE 1024
+volatile int input[SAMPLE_SIZE];
+int output[SAMPLE_SIZE];
+int out_checksum;
+
+void __attribute__((noinline)) checksum() {
+    int hash = 0;
+    int x = SAMPLE_SIZE;
+    // HWLoop for while-to-for converted
+    #pragma clang loop unroll(disable)
+    while (x > 0) {
+        hash += output[x];
+        x--;
+    }
+    out_checksum = hash;
+}
+
+void
+init_data() {
+    // set top borders to zero
+    #pragma clang loop unroll(disable)
+    for (int x = 0; x < SAMPLE_SIZE; x++) {
+        output[x] = 0;
+        input[x] = SAMPLE_SIZE - x;
+    }
+}
+
+void __attribute__((noinline)) profile(
+    unsigned char* restrict input_samples,
+    unsigned char* restrict output_samples) {
+    int sum = 0;
+    // HWLoop with fixed array size
+    #pragma clang loop unroll(disable)
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+        if (input_samples[i] > 123) {
+            output_samples[i] = 7;
+            sum++;
+        } else
+            output_samples[i] = 5;
+    }
+
+    // HWLoop with iteration count in variable
+    #pragma clang loop unroll(disable)
+    for (int i = 0; i < sum; i++) {
+        output_samples[i] = 0;
+    }
+
+    // HWLoop with iteration count (-ve) in variable
+    #pragma clang loop unroll(disable)
+    for (int i = sum; i > 0; i--) {
+        output_samples[i] = 0;
+    }
+}
+
+int
+main() {
+    init_data();
+    // Binarization kernel
+    profile((unsigned char*)input, (unsigned char*)output);
+    checksum();
+    return 0;
+}

--- a/testsuite/systemtest/bintools/Compiler/data/minimal_llvm_hwloop.adf
+++ b/testsuite/systemtest/bintools/Compiler/data/minimal_llvm_hwloop.adf
@@ -1,0 +1,652 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<adf version="1.10">
+
+  <little-endian/>
+
+  <bus name="B1">
+    <width>32</width>
+    <guard>
+      <always-true/>
+    </guard>
+    <guard>
+      <simple-expr>
+        <bool>
+          <name>bool</name>
+          <index>0</index>
+        </bool>
+      </simple-expr>
+    </guard>
+    <guard>
+      <inverted-expr>
+        <bool>
+          <name>bool</name>
+          <index>0</index>
+        </bool>
+      </inverted-expr>
+    </guard>
+    <guard>
+      <simple-expr>
+        <bool>
+          <name>bool</name>
+          <index>1</index>
+        </bool>
+      </simple-expr>
+    </guard>
+    <guard>
+      <inverted-expr>
+        <bool>
+          <name>bool</name>
+          <index>1</index>
+        </bool>
+      </inverted-expr>
+    </guard>
+    <segment name="seg1">
+      <writes-to/>
+    </segment>
+    <short-immediate>
+      <extension>zero</extension>
+      <width>32</width>
+    </short-immediate>
+  </bus>
+
+  <socket name="lsu_i1">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="lsu_o1">
+    <writes-to>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="lsu_i2">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="alu_comp_i1">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="alu_comp_i2">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="alu_comp_o1">
+    <writes-to>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="RF_i1">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="RF_o1">
+    <writes-to>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="bool_i1">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="bool_o1">
+    <writes-to>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="gcu_i1">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="gcu_i2">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="gcu_o1">
+    <writes-to>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="alu_1_i1">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="alu_1_i2">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <socket name="alu_1_o1">
+    <writes-to>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </writes-to>
+  </socket>
+
+  <socket name="gcu_i1_1">
+    <reads-from>
+      <bus>B1</bus>
+      <segment>seg1</segment>
+    </reads-from>
+  </socket>
+
+  <function-unit name="lsu">
+    <port name="in1t">
+      <connects-to>lsu_i1</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+    </port>
+    <port name="out1">
+      <connects-to>lsu_o1</connects-to>
+      <width>32</width>
+    </port>
+    <port name="in2">
+      <connects-to>lsu_i2</connects-to>
+      <width>32</width>
+    </port>
+    <operation>
+      <name>ld32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>2</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ld8</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>2</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ld16</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>2</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st8</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>st16</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ldu8</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>2</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ldu16</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>2</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <address-space>data</address-space>
+  </function-unit>
+
+  <function-unit name="alu">
+    <port name="in1t">
+      <connects-to>alu_comp_i1</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+    </port>
+    <port name="in2">
+      <connects-to>alu_comp_i2</connects-to>
+      <width>32</width>
+    </port>
+    <port name="out1">
+      <connects-to>alu_comp_o1</connects-to>
+      <width>32</width>
+    </port>
+    <operation>
+      <name>add</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>sub</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>eq</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>gt</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>gtu</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>and</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>ior</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>xor</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shr1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <operation>
+      <name>shru1_32</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <address-space/>
+  </function-unit>
+
+  <function-unit name="mul">
+    <port name="in1t">
+      <connects-to>alu_1_i1</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+    </port>
+    <port name="in2">
+      <connects-to>alu_1_i2</connects-to>
+      <width>32</width>
+    </port>
+    <port name="out1">
+      <connects-to>alu_1_o1</connects-to>
+      <width>32</width>
+    </port>
+    <operation>
+      <name>mul</name>
+      <bind name="1">in1t</bind>
+      <bind name="2">in2</bind>
+      <bind name="3">out1</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <writes name="3">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </writes>
+      </pipeline>
+    </operation>
+    <address-space/>
+  </function-unit>
+
+  <register-file name="RF">
+    <type>normal</type>
+    <size>5</size>
+    <width>32</width>
+    <max-reads>1</max-reads>
+    <max-writes>1</max-writes>
+    <port name="wr">
+      <connects-to>RF_i1</connects-to>
+    </port>
+    <port name="rd">
+      <connects-to>RF_o1</connects-to>
+    </port>
+  </register-file>
+
+  <register-file name="bool">
+    <type>normal</type>
+    <size>2</size>
+    <width>1</width>
+    <max-reads>1</max-reads>
+    <max-writes>1</max-writes>
+    <port name="wr">
+      <connects-to>bool_i1</connects-to>
+    </port>
+    <port name="rd">
+      <connects-to>bool_o1</connects-to>
+    </port>
+  </register-file>
+
+  <address-space name="data">
+    <width>8</width>
+    <min-address>0</min-address>
+    <max-address>16777215</max-address>
+  </address-space>
+
+  <address-space name="instructions">
+    <width>8</width>
+    <min-address>0</min-address>
+    <max-address>1048576</max-address>
+  </address-space>
+
+  <global-control-unit name="gcu">
+    <port name="pc">
+      <connects-to>gcu_i1</connects-to>
+      <width>32</width>
+      <triggers/>
+      <sets-opcode/>
+    </port>
+    <port name="cond">
+      <connects-to>gcu_i1_1</connects-to>
+      <width>32</width>
+    </port>
+    <special-port name="ra">
+      <connects-to>gcu_i2</connects-to>
+      <connects-to>gcu_o1</connects-to>
+      <width>32</width>
+    </special-port>
+    <return-address>ra</return-address>
+    <ctrl-operation>
+      <name>jump</name>
+      <bind name="1">pc</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </ctrl-operation>
+    <ctrl-operation>
+      <name>call</name>
+      <bind name="1">pc</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </ctrl-operation>
+    <ctrl-operation>
+      <name>hwloop</name>
+      <bind name="1">pc</bind>
+      <bind name="2">cond</bind>
+      <pipeline>
+        <reads name="1">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+        <reads name="2">
+          <start-cycle>0</start-cycle>
+          <cycles>1</cycles>
+        </reads>
+      </pipeline>
+    </ctrl-operation>
+    <address-space>instructions</address-space>
+    <delay-slots>3</delay-slots>
+    <guard-latency>1</guard-latency>
+  </global-control-unit>
+
+</adf>

--- a/testsuite/systemtest/bintools/Compiler/tcetest_llvm_hwloop.sh
+++ b/testsuite/systemtest/bintools/Compiler/tcetest_llvm_hwloop.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+### TCE TESTCASE
+### title: HWLOOP test for static and dynamic loop
+### xstdout: \n0x5f5f601c\n5
+
+ADF=data/minimal_llvm_hwloop.adf
+SRC=data/hwloop.c
+TPEF=$(mktemp tmpXXXXXX)
+
+tcecc -a $ADF -O3 --bubblefish2-scheduler -k out_checksum $SRC -o $TPEF
+echo quit | ttasim -a $ADF -p $TPEF -e 'run; x \/u w out_checksum;'
+tcedisasm $ADF $TPEF
+# We expect 5 hwloop
+grep hwloop $TPEF.S | wc -l
+
+rm -f $TPEF $TPEF.S

--- a/testsuite/systemtest/codesign/osal/BaseOperations/base_operations/hwloop.txt
+++ b/testsuite/systemtest/codesign/osal/BaseOperations/base_operations/hwloop.txt
@@ -1,0 +1,11 @@
+hwloop 3 3
+!advanceclock
+!advanceclock
+!advanceclock
+!advanceclock
+!advanceclock
+!advanceclock
+!advanceclock
+!advanceclock
+!advanceclock
+!quit


### PR DESCRIPTION
TCE backend now can benefit from LLVM's
generic hardware loop support. Current support
is limited to inner-loop whose iterations are
known before entering loop.