### PR TITLE
hwloop: Fix chain dependency bug for hwloop instr

### DIFF
--- a/tce/opset/base/Makefile.am
+++ b/tce/opset/base/Makefile.am
@@ -29,7 +29,7 @@ double_la_LIBADD = ../../src/libtce.la
 implicit_load_store_la_LIBADD = ../../src/libtce.la
 
 EXTRA_DIST = ${nobase_base_DATA} ${nobase_avalon_DATA} ${nobase_simple_io_DATA} ${nobase_double_DATA} \
-             {nobase_implicit_load_store_DATA}
+             ${nobase_implicit_load_store_DATA}
 
 PROJECT_ROOT = $(top_srcdir)
 SRC_ROOT_DIR = ${PROJECT_ROOT}/src

--- a/tce/opset/base/base.cc
+++ b/tce/opset/base/base.cc
@@ -2334,11 +2334,16 @@ END_DEFINE_STATE
 OPERATION_WITH_STATE(HWLOOP, HLOOP_SETUP)
 TRIGGER
     // sanity check
-    if (STATE.hwloopEnabled) {
-        RUNTIME_ERROR("Already hwloop is in progress");
-    }
     if (UINT(1) == 0) {
-        RUNTIME_ERROR("hwloop for iterations=0 is invalid");
+        RUNTIME_ERROR(
+            "Hardware loop invocation with 0 iterations is invalid.");
+    }
+    if (UINT(2) == 0) {
+        RUNTIME_ERROR(
+            "Hardware loop invocation with instruction length 0 is invalid.");
+    }
+    if (STATE.hwloopEnabled) {
+        RUNTIME_ERROR("Hardware loop execution already in progress.");
     }
 
     STATE.loopCounter = UINT(1)-1;

--- a/tce/src/applibs/LLVMBackend/plugin/TCEDAGToDAGISel.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/TCEDAGToDAGISel.cc
@@ -118,6 +118,12 @@ TCEDAGToDAGISel::~TCEDAGToDAGISel() {
  */
 void
 TCEDAGToDAGISel::Select(SDNode* n) {
+    // Custom nodes are already selected
+    if (n->isMachineOpcode()) {
+        n->setNodeId(-1);
+        return;
+    }
+
     SDLoc dl(n);
     if (n->getOpcode() >= ISD::BUILTIN_OP_END &&
         n->getOpcode() < TCEISD::FIRST_NUMBER) {

--- a/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.hh
+++ b/tce/src/applibs/LLVMBackend/plugin/TCEISelLowering.hh
@@ -86,6 +86,8 @@ namespace llvm {
         TCETargetLowering(TargetMachine &TM, const TCESubtarget &subt);
 
         virtual SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
+        virtual SDValue PerformDAGCombine(
+            SDNode *N, DAGCombinerInfo &DCI) const override;
 
         int getVarArgsFrameOffset() const /* override */ { return VarArgsFrameOffset; }
 

--- a/tce/src/applibs/Scheduler/Algorithms/BBSchedulerController.cc
+++ b/tce/src/applibs/Scheduler/Algorithms/BBSchedulerController.cc
@@ -525,7 +525,7 @@ BBSchedulerController::executeDDGPass(
 
     try {
         ddgPasses[fastest]->handleDDG(*ddg, *rm, targetMachine, minCycle);
-        if (bb.tripCount()) {
+        if (bbn->isHWLoop()) {
             bbn->predecessor()->updateHWloopLength(
                 ddg->largestCycle() + 1 - ddg->smallestCycle());
         }

--- a/tce/src/applibs/Scheduler/Algorithms/CopyingDelaySlotFiller.cc
+++ b/tce/src/applibs/Scheduler/Algorithms/CopyingDelaySlotFiller.cc
@@ -93,7 +93,7 @@ CopyingDelaySlotFiller::fillDelaySlots(
     }
 
     // do not try to fill loop scheduled, also skip epilog and prolog.
-    if (jumpingBB.isLoopScheduled()) {
+    if (jumpingBB.isLoopScheduled() || jumpingBB.isHWLoop()) {
         bbnStatus_[&jumpingBB] = BBN_BOTH_FILLED;
         return false;
     }
@@ -237,7 +237,8 @@ CopyingDelaySlotFiller::fillDelaySlots(
         BasicBlockNode& nextBBN = cfg_->headNode(edge);
 
         // cannot fill if the next is not normal BB.
-        if (!nextBBN.isNormalBB() || nextBBN.isLoopScheduled()) {
+        if (!nextBBN.isNormalBB() || nextBBN.isLoopScheduled() ||
+            nextBBN.isHWLoop()) {
             continue;
         }
 

--- a/tce/src/applibs/Scheduler/ProgramRepresentations/CFG/BasicBlockNode.cc
+++ b/tce/src/applibs/Scheduler/ProgramRepresentations/CFG/BasicBlockNode.cc
@@ -69,6 +69,7 @@ BasicBlockNode::BasicBlockNode(
     bbOwned_(true),
     entry_(entry), exit_(exit),
     scheduled_(false), refsUpdated_(false), loopScheduled_(false),
+    isHardwareLoop_(false),
     successor_(NULL), predecessor_(NULL), maximumSize_(INT_MAX) {
 
     if (entry || exit) {
@@ -96,6 +97,7 @@ BasicBlockNode::BasicBlockNode(
     entry_(false), exit_(false),
     scheduled_(scheduled), refsUpdated_(refsUpdated), 
     loopScheduled_(loopScheduled),
+    isHardwareLoop_(false),
     successor_(NULL), predecessor_(NULL), maximumSize_(INT_MAX) {
 }
 

--- a/tce/src/applibs/Scheduler/ProgramRepresentations/CFG/BasicBlockNode.hh
+++ b/tce/src/applibs/Scheduler/ProgramRepresentations/CFG/BasicBlockNode.hh
@@ -102,6 +102,19 @@ public:
     void setLoopScheduled() { loopScheduled_ = true; }
     void setBBOwnership(bool ownership = true) { bbOwned_ = ownership; }
 
+    /// Set true if the bbn is known to be a loop body of a hwloop with
+    /// loop pattern- preheader BB -> loop body (single BB) -> tail BB.
+    /// Furthermore, preheader should use HWLOOP instruction for its
+    /// fallthrough jump to its loop body.
+    void
+    setHWLoop(bool hwloop = true) {
+        isHardwareLoop_ = hwloop;
+    }
+    bool
+    isHWLoop() const {
+        return isHardwareLoop_;
+    }
+
     // Ordering of basic blocks in a procedure.
     // These are NULL if not set/decided.
     const BasicBlockNode* successor() const { return successor_; }
@@ -135,7 +148,9 @@ private:
     bool scheduled_;
     bool refsUpdated_;
     // if this bb was scheduled with loop scheduler
-    bool loopScheduled_; 
+    bool loopScheduled_;
+    /// true if this bb is known to be a hwloop body
+    bool isHardwareLoop_;
 
     BasicBlockNode* successor_;
     BasicBlockNode* predecessor_;

--- a/testsuite/systemtest/bintools/Compiler/tcetest_implicit_lsu.sh
+++ b/testsuite/systemtest/bintools/Compiler/tcetest_implicit_lsu.sh
@@ -8,7 +8,7 @@ SRC=data/implicit_ldst.c
 TPEF=$(mktemp tmpXXXXXX)
 
 # Run with implicit address
-tcecc --disable-llvm-hwloop -a $ADF -O3 -DILSU --bubblefish2-scheduler -k out_checksum $SRC -o $TPEF
+tcecc -a $ADF -O3 -DILSU --bubblefish2-scheduler -k out_checksum $SRC -o $TPEF
 echo quit | ttasim -a $ADF -p $TPEF -e 'run; x \/u w out_checksum;'
 
-rm -f $TPEF $TPEF.S
+rm -f $TPEF


### PR DESCRIPTION
If there is a node between hwloop and br, the pattern
matcher fails to select hwloop instructions. This fix
manually moves the hwloop instrution close to br by
updating chain dependencies manually.