### PR TITLE
hwloop: Add TCE backend hook for hwloop

### DIFF
--- a/tce/src/applibs/LLVMBackend/Makefile.am
+++ b/tce/src/applibs/LLVMBackend/Makefile.am
@@ -80,6 +80,8 @@ include_HEADERS = \
  plugin/TCEFrameInfo.hh \
  plugin/TCEFrameInfo.cc \
  plugin/TCETargetMachinePlugin.cc \
+ plugin/TCETargetTransformInfo.cc\
+ plugin/TCETargetTransformInfo.hh \
  plugin/PluginCompileWrapper.cc \
  TCETargetMachine.hh \
  TCETargetMachinePlugin.hh \

--- a/tce/src/applibs/LLVMBackend/TCETargetMachine.hh
+++ b/tce/src/applibs/LLVMBackend/TCETargetMachine.hh
@@ -42,6 +42,7 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
 
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetFrameLowering.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/CodeGen/SelectionDAGTargetInfo.h"
 
@@ -171,6 +172,11 @@ plugin_(plugin) {
 
         virtual TargetPassConfig *createPassConfig(
             PassManagerBase &PM) override;
+
+        TargetTransformInfo
+        getTargetTransformInfo(const Function& F) override {
+            return plugin_->getTargetTransformInfo(F);
+        }
 
         std::string operationName(unsigned opc) const {
             return plugin_->operationName(opc);

--- a/tce/src/applibs/LLVMBackend/TCETargetMachinePlugin.hh
+++ b/tce/src/applibs/LLVMBackend/TCETargetMachinePlugin.hh
@@ -97,6 +97,7 @@ namespace llvm {
    class TargetRegisterInfo;
    class TargetFrameLowering;
    class TargetSubtargetInfo;
+   class TargetTransformInfo;
    class TCESubtarget;
    class FunctionPass;
    class TCETargetMachine;
@@ -119,6 +120,8 @@ namespace llvm {
        virtual const TargetFrameLowering* getFrameLowering() const = 0;
        virtual TargetLowering* getTargetLowering() const = 0;
        virtual const TargetSubtargetInfo* getSubtarget() const = 0;
+       virtual TargetTransformInfo getTargetTransformInfo(
+           const Function& F) const = 0;
 
        virtual FunctionPass* createISelPass(TCETargetMachine* tm) = 0;
 

--- a/tce/src/applibs/LLVMBackend/plugin/PluginCompileWrapper.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/PluginCompileWrapper.cc
@@ -43,3 +43,4 @@
 #include "TCETargetObjectFile.cc"
 #include "TCETargetMachinePlugin.cc"
 #include "TCEFrameInfo.cc"
+#include "TCETargetTransformInfo.cc"

--- a/tce/src/applibs/LLVMBackend/plugin/TCETargetMachinePlugin.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/TCETargetMachinePlugin.cc
@@ -46,6 +46,7 @@
 #include "CIStringSet.hh"
 #include "LLVMTCECmdLineOptions.hh"
 #include "TCEStubTargetMachine.hh"
+#include "TCETargetTransformInfo.hh"
 
 using namespace llvm;
 
@@ -60,6 +61,8 @@ public:
     virtual const TargetRegisterInfo* getRegisterInfo() const override;
     virtual const TargetFrameLowering* getFrameLowering() const override;
     virtual TargetLowering* getTargetLowering() const override;
+    virtual TargetTransformInfo getTargetTransformInfo(
+        const Function& F) const override;
     virtual const TargetSubtargetInfo* getSubtarget() const override;
 
     virtual FunctionPass* createISelPass(TCETargetMachine* tm) override;
@@ -296,6 +299,11 @@ GeneratedTCEPlugin::getRegisterInfo() const {
 const TargetFrameLowering* 
 GeneratedTCEPlugin::getFrameLowering() const {
     return frameInfo_;
+}
+
+TargetTransformInfo
+GeneratedTCEPlugin::getTargetTransformInfo(const Function& F) const {
+    return TargetTransformInfo(TCETTIImpl(tm_, F));
 }
 
 /**

--- a/tce/src/applibs/LLVMBackend/plugin/TCETargetTransformInfo.cc
+++ b/tce/src/applibs/LLVMBackend/plugin/TCETargetTransformInfo.cc
@@ -1,0 +1,66 @@
+/*
+    Copyright (c) 2021-2022 Kanishkan Vadivel/Eindhoven University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+/**
+ * @file TCETargetTransformInfo.cc
+ *
+ * Declaration of TCETargetTransformInfo class.
+ *
+ * @author Kanishkan Vadivel 2022
+ */
+
+#include "CompilerWarnings.hh"
+IGNORE_COMPILER_WARNING("-Wunused-parameter")
+
+#include "LLVMTCECmdLineOptions.hh"
+#include "TCETargetTransformInfo.hh"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "tcetti"
+
+bool
+TCETTIImpl::isHardwareLoopProfitable(
+    Loop *L, ScalarEvolution &SE, AssumptionCache &AC,
+    TargetLibraryInfo *LibInfo, HardwareLoopInfo &HWLoopInfo) {
+    // Check TCE flag for hwloop
+    LLVMTCECmdLineOptions *options =
+        dynamic_cast<LLVMTCECmdLineOptions *>(Application::cmdLineOptions());
+    if (options == NULL || options->disableHWLoops()) return false;
+
+    // We should do hwloop only for single BB loop
+    if (L->getNumBlocks() != 1) {
+        LLVM_DEBUG(
+            dbgs() << "HWLoops: Loop has " << L->getNumBlocks()
+                   << " BB. Not converting to hwloop: " << L->getName()
+                   << "\n");
+        return false;
+    }
+
+    // Set counter type and loop decrement value
+    LLVMContext &C = L->getHeader()->getContext();
+    HWLoopInfo.CountType = Type::getInt32Ty(C);
+    HWLoopInfo.LoopDecrement = ConstantInt::get(HWLoopInfo.CountType, 1);
+    HWLoopInfo.IsNestingLegal = false;
+    return true;
+}

--- a/tce/src/applibs/LLVMBackend/plugin/TCETargetTransformInfo.hh
+++ b/tce/src/applibs/LLVMBackend/plugin/TCETargetTransformInfo.hh
@@ -1,0 +1,71 @@
+/*
+    Copyright (c) 2021-2022 Kanishkan Vadivel/Eindhoven University.
+
+    This file is part of TTA-Based Codesign Environment (TCE).
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+/**
+ * @file TCETargeTransformInfo.hh
+ *
+ * Declaration of TCETargetTransformInfo class.
+ *
+ * @author Kanishkan Vadivel 2022
+ */
+
+#ifndef TTA_TCE_TARGET_TRANSFORM_INFO_HH
+#define TTA_TCE_TARGET_TRANSFORM_INFO_HH
+
+#include <llvm/Analysis/TargetTransformInfo.h>
+#include <llvm/CodeGen/BasicTTIImpl.h>
+
+#include "TCETargetMachine.hh"
+
+namespace llvm {
+
+class TCETTIImpl : public BasicTTIImplBase<TCETTIImpl> {
+    typedef BasicTTIImplBase<TCETTIImpl> BaseT;
+    typedef TargetTransformInfo TTI;
+    friend BaseT;
+
+    const TCESubtarget *ST;
+    const TCETargetLowering *TLI;
+
+    const TCESubtarget *
+    getST() const {
+        return ST;
+    }
+    const TCETargetLowering *
+    getTLI() const {
+        return TLI;
+    }
+
+public:
+    explicit TCETTIImpl(const TCETargetMachine *TM, const Function &F)
+        : BaseT(TM, F.getParent()->getDataLayout()),
+          ST(TM->getSubtargetImpl()),
+          TLI(static_cast<const TCETargetLowering *>(
+              ST->getTargetLowering())) {}
+    bool isHardwareLoopProfitable(
+        Loop *L, ScalarEvolution &SE, AssumptionCache &AC,
+        TargetLibraryInfo *LibInfo, HardwareLoopInfo &HWLoopInfo);
+};
+}  // namespace llvm
+
+#endif

--- a/tce/src/bintools/Compiler/tcecc.in
+++ b/tce/src/bintools/Compiler/tcecc.in
@@ -1757,8 +1757,6 @@ if options.adf_file != "":
 
     if options.disable_llvm_hwloop:
         command += " --disable-hwloops"
-    else:
-        options.llvm_args += " -force-hardware-loops -hardware-loop-decrement=1 -hardware-loop-counter-bitwidth=32"
 
     if options.llvm_args != "":
         command += " --llvm-args=\"" + options.llvm_args + "\""

--- a/testsuite/systemtest/bintools/Compiler/data/hwloop.c
+++ b/testsuite/systemtest/bintools/Compiler/data/hwloop.c
@@ -17,11 +17,17 @@ void __attribute__((noinline)) checksum() {
 
 void
 init_data() {
+    // Loop unroll with unroll condition (SAMPLE_SIZE % N != 0)
+    // Should not be converted to hwloop
+    #pragma clang loop unroll_count(5)
+    for (int x = 0; x < SAMPLE_SIZE; x++) {
+        input[x] = SAMPLE_SIZE - x;
+    }
+
     // set top borders to zero
     #pragma clang loop unroll(disable)
     for (int x = 0; x < SAMPLE_SIZE; x++) {
         output[x] = 0;
-        input[x] = SAMPLE_SIZE - x;
     }
 }
 


### PR DESCRIPTION
Note that, we run the HWLoop pass in the backend. So, the IR can still be independent of the target features.