### PR TITLE
Fixes layout-related assertions and runtime errors in ProDe

### DIFF
--- a/tce/src/procgen/ProDe/AboutDialog.cc
+++ b/tce/src/procgen/ProDe/AboutDialog.cc
@@ -126,7 +126,7 @@ AboutDialog::createContents(
     wxStaticLine *item7 =
 	new wxStaticLine(parent, -1, wxDefaultPosition,
 			 wxSize(20,-1), wxLI_HORIZONTAL);
-    item0->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item7, 0, wxGROW | wxALL, 5);
     wxButton *item8 =
 	new wxButton(parent, wxID_OK, wxT("&OK"), wxDefaultPosition,
 		     wxDefaultSize, 0);

--- a/tce/src/procgen/ProDe/AboutDialog.cc
+++ b/tce/src/procgen/ProDe/AboutDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of AboutDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <string>

--- a/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
@@ -510,13 +510,13 @@ AddFUFromHDBDialog::createContents(
     item0->Add(filterCtrl_, 0, wxGROW|wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_ADD, wxT("&Add"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxStaticLine *item3 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
     item0->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxButton *item4 = new wxButton( parent, ID_CLOSE, wxT("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer) {
         parent->SetSizer( item0 );

--- a/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of AddFUFromHDBDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
@@ -513,7 +513,7 @@ AddFUFromHDBDialog::createContents(
     item0->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item3 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxButton *item4 = new wxButton( parent, ID_CLOSE, wxT("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );

--- a/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddFUFromHDBDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of AddFUFromHDBDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -154,7 +154,7 @@ AddFUFromHDBDialog::AddFUFromHDBDialog(
     string iconPath =
         Environment::iconDirPath() + FileSystem::DIRECTORY_SEPARATOR;
 
-    wxImageList* imageList = new wxImageList();
+    wxImageList *imageList = new wxImageList(13, 17);
     imageList->Add(wxIcon(
         WxConversion::toWxString(iconPath + ProDeConstants::ICON_SORT_DESC)));
     imageList->Add(wxIcon(

--- a/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of AddIUFromHDBDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of AddIUFromHDBDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -156,7 +156,7 @@ AddIUFromHDBDialog::AddIUFromHDBDialog(
     string iconPath =
         Environment::iconDirPath() + FileSystem::DIRECTORY_SEPARATOR;
 
-    wxImageList* imageList = new wxImageList();
+    wxImageList *imageList = new wxImageList(13, 17);
     imageList->Add(wxIcon(
         WxConversion::toWxString(iconPath + ProDeConstants::ICON_SORT_DESC)));
     imageList->Add(wxIcon(

--- a/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
@@ -410,13 +410,13 @@ AddIUFromHDBDialog::createContents(
     item0->Add( item1, 0, wxGROW|wxALL, 5 );
 
     wxButton *item2 = new wxButton( parent, ID_ADD, wxT("&Add"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxStaticLine *item3 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
     item0->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxButton *item4 = new wxButton( parent, ID_CLOSE, wxT("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer) {
         parent->SetSizer( item0 );

--- a/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddIUFromHDBDialog.cc
@@ -413,7 +413,7 @@ AddIUFromHDBDialog::createContents(
     item0->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item3 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxButton *item4 = new wxButton( parent, ID_CLOSE, wxT("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );

--- a/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
@@ -395,13 +395,13 @@ AddRFFromHDBDialog::createContents(
     item0->Add( item1, 0, wxGROW|wxALL, 5 );
 
     wxButton *item2 = new wxButton( parent, ID_ADD, wxT("&Add"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxStaticLine *item3 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
     item0->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxButton *item4 = new wxButton( parent, ID_CLOSE, wxT("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer) {
         parent->SetSizer( item0 );

--- a/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
@@ -398,7 +398,7 @@ AddRFFromHDBDialog::createContents(
     item0->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item3 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxButton *item4 = new wxButton( parent, ID_CLOSE, wxT("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );

--- a/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of AddRFFromHDBDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -165,7 +165,7 @@ AddRFFromHDBDialog::AddRFFromHDBDialog(
     string iconPath =
         Environment::iconDirPath() + FileSystem::DIRECTORY_SEPARATOR;
 
-    wxImageList* imageList = new wxImageList();
+    wxImageList *imageList = new wxImageList(13, 17);
     imageList->Add(wxIcon(
         WxConversion::toWxString(iconPath + ProDeConstants::ICON_SORT_DESC)));
     imageList->Add(wxIcon(

--- a/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
+++ b/tce/src/procgen/ProDe/AddRFFromHDBDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of AddRFFromHDBDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/AddressSpaceDialog.cc
+++ b/tce/src/procgen/ProDe/AddressSpaceDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of AddressSpaceDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -503,9 +503,9 @@ AddressSpaceDialog::createContents(
     nameSizer_ = item2;
 
     wxTextCtrl *item4 = new wxTextCtrl(parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(160,-1), 0);
-    item2->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item4, 0, wxGROW | wxALL, 5);
 
-    item1->Add( item2, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxGROW | wxALL, 5);
 
     wxStaticBox *item6 = new wxStaticBox( parent, -1, wxT("Min-Address") );
     wxStaticBoxSizer *item5 = new wxStaticBoxSizer( item6, wxVERTICAL );
@@ -515,16 +515,16 @@ AddressSpaceDialog::createContents(
     wxASSERT( item7 );
     item5->Add( item7, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxStaticBox *item9 = new wxStaticBox( parent, -1, wxT("Width:") );
     wxStaticBoxSizer *item8 = new wxStaticBoxSizer( item9, wxVERTICAL );
     widthSizer_ = item8;
 
     wxSpinCtrl *item10 = new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1, wxT("Spin"));
-    item8->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item8->Add(item10, 0, wxGROW | wxALL, 5);
 
-    item1->Add( item8, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item8, 0, wxGROW | wxALL, 5);
 
     wxStaticBox *item12 = new wxStaticBox( parent, -1, wxT("Max-Address") );
     wxStaticBoxSizer *item11 = new wxStaticBoxSizer( item12, wxVERTICAL );
@@ -537,14 +537,14 @@ AddressSpaceDialog::createContents(
     wxBoxSizer *bitSizer = new wxBoxSizer(wxHORIZONTAL);
 
     wxStaticText *bitText = new wxStaticText(parent, -1, wxT("Bits:"));
-    bitSizer->Add( bitText, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    bitSizer->Add(bitText, 0, wxGROW | wxALL, 5);
 
     wxSpinCtrl *bitWidth = new wxSpinCtrl( parent, ID_BIT_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1);
-    bitSizer->Add( bitWidth, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    bitSizer->Add(bitWidth, 0, wxGROW | wxALL, 5);
 
-    item11->Add( bitSizer, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item11->Add(bitSizer, 0, wxGROW | wxALL, 5);
 
-    item1->Add( item11, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item11, 0, wxGROW | wxALL, 5);
 
     // address space id box
     wxStaticBox *itemIdBox = new wxStaticBox(parent, -1, wxT("ID number:"));
@@ -563,7 +563,7 @@ AddressSpaceDialog::createContents(
     wxBoxSizer *sizerOnRight = new wxBoxSizer(wxVERTICAL);
     
     wxSpinCtrl *itemIdSpinCtrl = new wxSpinCtrl( parent, ID_SPIN_ID, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 2147483647, 1, wxT("Spin") );
-    sizerOnRight->Add( itemIdSpinCtrl, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    sizerOnRight->Add(itemIdSpinCtrl, 0, wxGROW | wxALL, 5);
     idSpinCtrl_ = itemIdSpinCtrl;
     
     wxButton *addButton = new wxButton( parent, ID_ADD_ID, wxT("Add"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -573,8 +573,8 @@ AddressSpaceDialog::createContents(
     sizerOnRight->Add( deleteButton, 0, wxALIGN_CENTER|wxALL, 5 );
 
     idSizer_->Add( sizerOnRight, 0, wxALIGN_CENTER|wxALL, 5 );
-    item1->Add( idSizer_, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-    
+    item1->Add(idSizer_, 0, wxGROW | wxALL, 5);
+
     assert (idSizer_ != NULL);
     assert (idListCtrl_ != NULL);
     assert (idSpinCtrl_ != NULL);
@@ -583,7 +583,7 @@ AddressSpaceDialog::createContents(
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticLine *item14 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item14, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item14, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item15 = new wxGridSizer( 2, 0, 0 );
 
@@ -600,7 +600,7 @@ AddressSpaceDialog::createContents(
 
     item15->Add( item17, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item15, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item15, 0, wxGROW, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/AddressSpaceDialog.cc
+++ b/tce/src/procgen/ProDe/AddressSpaceDialog.cc
@@ -598,7 +598,7 @@ AddressSpaceDialog::createContents(
     wxButton *item19 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item17->Add( item19, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item15->Add( item17, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item15->Add(item17, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item15, 0, wxGROW, 5);
 

--- a/tce/src/procgen/ProDe/AddressSpaceDialog.cc
+++ b/tce/src/procgen/ProDe/AddressSpaceDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of AddressSpaceDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/AddressSpaceDialog.cc
+++ b/tce/src/procgen/ProDe/AddressSpaceDialog.cc
@@ -521,7 +521,9 @@ AddressSpaceDialog::createContents(
     wxStaticBoxSizer *item8 = new wxStaticBoxSizer( item9, wxVERTICAL );
     widthSizer_ = item8;
 
-    wxSpinCtrl *item10 = new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1, wxT("Spin"));
+    wxSpinCtrl *item10 =
+        new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1, wxT("Spin"));
     item8->Add(item10, 0, wxGROW | wxALL, 5);
 
     item1->Add(item8, 0, wxGROW | wxALL, 5);
@@ -539,7 +541,9 @@ AddressSpaceDialog::createContents(
     wxStaticText *bitText = new wxStaticText(parent, -1, wxT("Bits:"));
     bitSizer->Add(bitText, 0, wxGROW | wxALL, 5);
 
-    wxSpinCtrl *bitWidth = new wxSpinCtrl( parent, ID_BIT_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1);
+    wxSpinCtrl *bitWidth =
+        new wxSpinCtrl(parent, ID_BIT_WIDTH, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     bitSizer->Add(bitWidth, 0, wxGROW | wxALL, 5);
 
     item11->Add(bitSizer, 0, wxGROW | wxALL, 5);
@@ -561,8 +565,10 @@ AddressSpaceDialog::createContents(
     idListCtrl_->InsertColumn(0, _("ID"));
     
     wxBoxSizer *sizerOnRight = new wxBoxSizer(wxVERTICAL);
-    
-    wxSpinCtrl *itemIdSpinCtrl = new wxSpinCtrl( parent, ID_SPIN_ID, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 2147483647, 1, wxT("Spin") );
+
+    wxSpinCtrl *itemIdSpinCtrl =
+        new wxSpinCtrl(parent, ID_SPIN_ID, wxT("0"), wxDefaultPosition,
+                       wxDefaultSize, 0, 0, 2147483647, 1, wxT("Spin"));
     sizerOnRight->Add(itemIdSpinCtrl, 0, wxGROW | wxALL, 5);
     idSpinCtrl_ = itemIdSpinCtrl;
     

--- a/tce/src/procgen/ProDe/AddressSpacesDialog.cc
+++ b/tce/src/procgen/ProDe/AddressSpacesDialog.cc
@@ -385,7 +385,7 @@ AddressSpacesDialog::createContents( wxWindow *parent, bool call_fit, bool set_s
     wxButton *item11 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item9->Add( item11, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item7->Add( item9, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item7->Add(item9, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item7, 0, wxGROW, 5);
 

--- a/tce/src/procgen/ProDe/AddressSpacesDialog.cc
+++ b/tce/src/procgen/ProDe/AddressSpacesDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of AddressSpacesDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -367,10 +367,10 @@ AddressSpacesDialog::createContents( wxWindow *parent, bool call_fit, bool set_s
     wxButton *item5 = new wxButton( parent, ID_DELETE, wxT("&Delete"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item2, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item2, 0, wxGROW, 5);
 
     wxStaticLine *item6 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item6, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item7 = new wxGridSizer( 2, 0, 0 );
 
@@ -387,7 +387,7 @@ AddressSpacesDialog::createContents( wxWindow *parent, bool call_fit, bool set_s
 
     item7->Add( item9, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item7, 0, wxGROW, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/AddressSpacesDialog.cc
+++ b/tce/src/procgen/ProDe/AddressSpacesDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of AddressSpacesDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
+++ b/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of AutoSelectImplementationsDialog class.
  *
- * @author Mikko J�rvel� 2013 (jarvela7-no.spam-cs.tut.fi)
+ * @author Mikko Järvelä 2013 (jarvela7-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
+++ b/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of AutoSelectImplementationsDialog class.
  *
- * @author Mikko Järvelä 2013 (jarvela7-no.spam-cs.tut.fi)
+ * @author Mikko Jï¿½rvelï¿½ 2013 (jarvela7-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -478,8 +478,8 @@ AutoSelectImplementationsDialog::createContents(
     item0->Add( cboxSizer, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item5 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-    
+    item0->Add(item5, 0, wxGROW | wxALL, 5);
+
     wxBoxSizer *item6 = new wxBoxSizer( wxHORIZONTAL );
 
     wxButton *closeButton = new wxButton( parent, ID_CLOSE, wxT("Close"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
+++ b/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
@@ -447,7 +447,7 @@ AutoSelectImplementationsDialog::createContents(
     wxBoxSizer *item1 = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *itemText = new wxStaticText( parent, ID_TEXT, wxT("HDB file:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( itemText, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(itemText, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs2 = (wxString*) NULL;
     wxChoice *item2 = new wxChoice( parent, ID_HDB_CHOICE, wxDefaultPosition, wxSize(250,-1), 0, strs2, 0 );
@@ -485,8 +485,7 @@ AutoSelectImplementationsDialog::createContents(
     wxButton *closeButton = new wxButton( parent, ID_CLOSE, wxT("Close"), wxDefaultPosition, wxDefaultSize, 0 );
     item6->Add( closeButton, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-
+    item0->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
+++ b/tce/src/procgen/ProDe/AutoSelectImplementationsDialog.cc
@@ -447,7 +447,7 @@ AutoSelectImplementationsDialog::createContents(
     wxBoxSizer *item1 = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *itemText = new wxStaticText( parent, ID_TEXT, wxT("HDB file:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add(itemText, 0, wxALIGN_RIGHT | wxALL, 5);
+    item1->Add(itemText, 0, wxALL, 5);
 
     wxString *strs2 = (wxString*) NULL;
     wxChoice *item2 = new wxChoice( parent, ID_HDB_CHOICE, wxDefaultPosition, wxSize(250,-1), 0, strs2, 0 );

--- a/tce/src/procgen/ProDe/BlockImplementationDialog.cc
+++ b/tce/src/procgen/ProDe/BlockImplementationDialog.cc
@@ -26,8 +26,8 @@
  *
  * Implementation of BlockImplementationDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
- * @author Esa Määttä 2007 (esa.maatta-no.spam-tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Esa Mï¿½ï¿½ttï¿½ 2007 (esa.maatta-no.spam-tut.fi)
  * @note rating: red
  */
 
@@ -383,10 +383,10 @@ BlockImplementationDialog::createContents(
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxListCtrl *item4 = new wxListCtrl( parent, ID_LIST, wxDefaultPosition, wxSize(300,120), wxLC_REPORT|wxSUNKEN_BORDER );
-    item0->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item4, 0, wxGROW | wxALL, 5);
 
     wxStaticLine *item5 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item6 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/BlockImplementationDialog.cc
+++ b/tce/src/procgen/ProDe/BlockImplementationDialog.cc
@@ -26,8 +26,8 @@
  *
  * Implementation of BlockImplementationDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2006 (vjaaskel-no.spam-cs.tut.fi)
- * @author Esa M��tt� 2007 (esa.maatta-no.spam-tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Esa Määttä 2007 (esa.maatta-no.spam-tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/BlockImplementationDialog.cc
+++ b/tce/src/procgen/ProDe/BlockImplementationDialog.cc
@@ -396,7 +396,7 @@ BlockImplementationDialog::createContents(
     wxButton *item8 = new wxButton( parent, wxID_OK, wxT("&OK"), wxDefaultPosition, wxDefaultSize, 0 );
     item6->Add( item8, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/BridgeDialog.cc
+++ b/tce/src/procgen/ProDe/BridgeDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of BridgeDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -485,14 +485,14 @@ BridgeDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
 
     wxString *strs6 = (wxString*) NULL;
     wxChoice *item6 = new wxChoice( parent, ID_INPUT_BUS, wxDefaultPosition, wxSize(100,-1), 0, strs6, 0 );
-    item2->Add( item6, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item7 = new wxStaticText( parent, ID_LABEL_OUTPUT_BUS, wxT("Output Bus:"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item7, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxString *strs8 = (wxString*) NULL;
     wxChoice *item8 = new wxChoice( parent, ID_OUTPUT_BUS, wxDefaultPosition, wxSize(100,-1), 0, strs8, 0 );
-    item2->Add( item8, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item8, 0, wxGROW | wxALL, 5);
 
     item1->Add( item2, 0, wxALIGN_CENTER|wxALL, 5 );
 
@@ -504,17 +504,17 @@ BridgeDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     item9->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item11 = new wxStaticText( parent, ID_LABEL_OPPOSITE_NAME, wxT("Opposite Bridge Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item9->Add( item11, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 15 );
+    item9->Add(item11, 0, wxGROW, 15);
 
     wxTextCtrl *item12 = new wxTextCtrl( parent, ID_OPPOSITE_BRIDGE, wxT(""), wxDefaultPosition, wxSize(80,-1), 0 );
-    item9->Add( item12, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item9->Add(item12, 0, wxGROW | wxALL, 5);
 
-    item1->Add( item9, 0, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item1->Add(item9, 0, wxGROW | wxALL, 5);
 
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticLine *item13 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item13, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item13, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item14 = new wxGridSizer( 2, 0, 0 );
 

--- a/tce/src/procgen/ProDe/BridgeDialog.cc
+++ b/tce/src/procgen/ProDe/BridgeDialog.cc
@@ -475,20 +475,20 @@ BridgeDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxFlexGridSizer *item2 = new wxFlexGridSizer( 2, 0, 0 );
 
     wxStaticText *item3 = new wxStaticText( parent, ID_LABEL_NAME, wxT("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item3, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item3, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item4 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(120,-1), 0 );
     item2->Add( item4, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item5 = new wxStaticText( parent, ID_LABEL_INPUT_BUS, wxT("Input Bus:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item5, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item5, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs6 = (wxString*) NULL;
     wxChoice *item6 = new wxChoice( parent, ID_INPUT_BUS, wxDefaultPosition, wxSize(100,-1), 0, strs6, 0 );
     item2->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item7 = new wxStaticText( parent, ID_LABEL_OUTPUT_BUS, wxT("Output Bus:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item7, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item7, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs8 = (wxString*) NULL;
     wxChoice *item8 = new wxChoice( parent, ID_OUTPUT_BUS, wxDefaultPosition, wxSize(100,-1), 0, strs8, 0 );
@@ -529,7 +529,7 @@ BridgeDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxButton *item18 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item16->Add( item18, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item14->Add( item16, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item14->Add(item16, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add( item14, 0, wxALIGN_CENTER, 5 );
 

--- a/tce/src/procgen/ProDe/BridgeDialog.cc
+++ b/tce/src/procgen/ProDe/BridgeDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of BridgeDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/BusDialog.cc
+++ b/tce/src/procgen/ProDe/BusDialog.cc
@@ -1264,7 +1264,7 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxButton *item26 = new wxButton( parent, ID_SEGMENT_DOWN, wxT("Down"), wxDefaultPosition, wxSize(50,-1), 0 );
     item24->Add( item26, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item21->Add( item24, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item21->Add(item24, 0, wxALL, 5);
 
     item18->Add(item21, 0, wxGROW | wxALL, 5);
 

--- a/tce/src/procgen/ProDe/BusDialog.cc
+++ b/tce/src/procgen/ProDe/BusDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of BusDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/BusDialog.cc
+++ b/tce/src/procgen/ProDe/BusDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of BusDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -1193,7 +1193,7 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxTextCtrl *item6 = new wxTextCtrl( parent, ID_BUS_NAME, wxT(""), wxDefaultPosition, wxSize(200,-1), 0 );
     item4->Add( item6, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item4, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item7 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -1203,10 +1203,10 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_BUS_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 1024, 1 );
     item7->Add( item9, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item7, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item2, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-    //item1->Add( item2, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item2, 0, wxGROW | wxALL, 5);
+    // item1->Add( item2, 0, wxGROW|wxALL, 5 );
 
     wxStaticBox *item11 = new wxStaticBox( parent, -1, wxT("Short Immediate:") );
     wxStaticBoxSizer *item10 = new wxStaticBoxSizer( item11, wxVERTICAL );
@@ -1220,7 +1220,7 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxSpinCtrl *item14 = new wxSpinCtrl( parent, ID_SI_WIDTH, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 1000, 0 );
     item12->Add( item14, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item10->Add( item12, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item10->Add(item12, 0, wxGROW | wxALL, 5);
 
     wxString strs15[] =
     {
@@ -1230,8 +1230,8 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxRadioBox *item15 = new wxRadioBox( parent, ID_SI_EXTENSION, wxT("Extension"), wxDefaultPosition, wxDefaultSize, 2, strs15, 1, wxRA_SPECIFY_ROWS );
     item10->Add( item15, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-    //item1->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item10, 0, wxGROW | wxALL, 5);
+    // item1->Add( item10, 0, wxGROW|wxALL, 5 );
 
     wxCheckBox *item16 = new wxCheckBox( parent, ID_TRUE_GUARD, wxT("Always true guard"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item16, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -1266,7 +1266,7 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
 
     item21->Add( item24, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
 
-    item18->Add( item21, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item18->Add(item21, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item27 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/BusDialog.cc
+++ b/tce/src/procgen/ProDe/BusDialog.cc
@@ -1200,7 +1200,9 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_BUS_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item7->Add( item8, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_BUS_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 1024, 1 );
+    wxSpinCtrl *item9 =
+        new wxSpinCtrl(parent, ID_BUS_WIDTH, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 1024, 1);
     item7->Add( item9, 0, wxALIGN_CENTER|wxALL, 5 );
 
     item2->Add(item7, 0, wxGROW | wxALL, 5);
@@ -1217,7 +1219,9 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxStaticText *item13 = new wxStaticText( parent, ID_LABEL_SI_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item12->Add( item13, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    wxSpinCtrl *item14 = new wxSpinCtrl( parent, ID_SI_WIDTH, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 1000, 0 );
+    wxSpinCtrl *item14 =
+        new wxSpinCtrl(parent, ID_SI_WIDTH, wxT("0"), wxDefaultPosition,
+                       wxDefaultSize, 0, 0, 1000, 0);
     item12->Add( item14, 0, wxALIGN_CENTER|wxALL, 5 );
 
     item10->Add(item12, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/BusDialog.cc
+++ b/tce/src/procgen/ProDe/BusDialog.cc
@@ -1228,16 +1228,16 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
         wxT("Sign")
     };
     wxRadioBox *item15 = new wxRadioBox( parent, ID_SI_EXTENSION, wxT("Extension"), wxDefaultPosition, wxDefaultSize, 2, strs15, 1, wxRA_SPECIFY_ROWS );
-    item10->Add( item15, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item10->Add(item15, 0, wxALL, 5);
 
     item0->Add(item10, 0, wxGROW | wxALL, 5);
     // item1->Add( item10, 0, wxGROW|wxALL, 5 );
 
     wxCheckBox *item16 = new wxCheckBox( parent, ID_TRUE_GUARD, wxT("Always true guard"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item16, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item16, 0, wxALL, 5);
 
     wxCheckBox *item17 = new wxCheckBox( parent, ID_FALSE_GUARD, wxT("Always false guard"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item17, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item17, 0, wxALL, 5);
 
     item0->Add( item1, 0, wxGROW|wxALL, 5 );
 
@@ -1341,7 +1341,7 @@ BusDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxButton *item47 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item45->Add( item47, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item45, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item45, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/CallExplorerPlugin.cc
+++ b/tce/src/procgen/ProDe/CallExplorerPlugin.cc
@@ -403,7 +403,7 @@ CallExplorerPluginWindow::createContents(
     item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_TEXT, wxT("Plugin Parameters:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item6, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item6, 0, wxALL, 5);
 
     wxListCtrl *item7 = new wxListCtrl( parent, ID_PARAM_LIST, wxDefaultPosition, wxSize(400,200), wxLC_REPORT|wxSUNKEN_BORDER );
     item0->Add( item7, 0, wxALIGN_CENTER|wxALL, 5 );
@@ -418,14 +418,14 @@ CallExplorerPluginWindow::createContents(
     item9->Add( item10, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxButton *item11 = new wxButton( parent, ID_RUN, wxT("&Run Plugin"), wxDefaultPosition, wxDefaultSize, 0 );
-    item9->Add( item11, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item9->Add(item11, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxBoxSizer *item12 = new wxBoxSizer( wxHORIZONTAL );
 
     wxButton *item13 = new wxButton( parent, wxID_CLOSE, wxT("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
     item12->Add( item13, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item9->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item9->Add(item12, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item9, 0, wxGROW, 5);
 

--- a/tce/src/procgen/ProDe/CallExplorerPlugin.cc
+++ b/tce/src/procgen/ProDe/CallExplorerPlugin.cc
@@ -398,9 +398,9 @@ CallExplorerPluginWindow::createContents(
     item1->Add( item4, 0, wxFIXED_MINSIZE|wxALL, 5 );
 
     wxTextCtrl *item5 = new wxTextCtrl( parent, ID_DESCRIPTION_FIELD, wxT(""), wxDefaultPosition, wxSize(240,150), wxTE_MULTILINE|wxTE_READONLY );
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_TEXT, wxT("Plugin Parameters:"), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item6, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -410,7 +410,7 @@ CallExplorerPluginWindow::createContents(
 
     wxGridSizer *item8 = new wxGridSizer( 3, 0, 0 );
 
-    item0->Add( item8, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item8, 0, wxGROW, 5);
 
     wxGridSizer *item9 = new wxGridSizer( 3, 0, 0 );
 
@@ -427,7 +427,7 @@ CallExplorerPluginWindow::createContents(
 
     item9->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item9, 0, wxGROW, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/EditParameterDialog.cc
+++ b/tce/src/procgen/ProDe/EditParameterDialog.cc
@@ -174,7 +174,7 @@ EditParameterDialog::createContents(
     wxStaticText *item3 = new wxStaticText( parent, ID_NAME, wxT("xxxxxxxxxxxxxxx"), wxDefaultPosition, wxSize(150,-1), 0 );
     item1->Add( item3, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item1, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxBoxSizer *item4 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -184,7 +184,7 @@ EditParameterDialog::createContents(
     wxStaticText *item6 = new wxStaticText( parent, ID_TYPE, wxT("xxxxxxxxxxxx"), wxDefaultPosition, wxSize(150,-1), 0 );
     item4->Add( item6, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxBoxSizer *item7 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -202,7 +202,7 @@ EditParameterDialog::createContents(
     item10->Add( item11, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxButton *item12 = new wxButton( parent, ID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-    item10->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item10->Add(item12, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add( item10, 0, wxALIGN_CENTER|wxALL, 5 );
 

--- a/tce/src/procgen/ProDe/EditParameterDialog.cc
+++ b/tce/src/procgen/ProDe/EditParameterDialog.cc
@@ -202,7 +202,7 @@ EditParameterDialog::createContents(
     item10->Add( item11, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxButton *item12 = new wxButton( parent, ID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
-    item10->Add(item12, 0, wxALIGN_RIGHT | wxALL, 5);
+    item10->Add(item12, 0, wxALL, 5);
 
     item0->Add( item10, 0, wxALIGN_CENTER|wxALL, 5 );
 

--- a/tce/src/procgen/ProDe/FUDialog.cc
+++ b/tce/src/procgen/ProDe/FUDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of FUDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -774,7 +774,7 @@ FUDialog::createContents(wxWindow* parent, bool call_fit, bool set_sizer) {
     operationsSizer_ = item7;
 
     wxListCtrl *item9 = new wxListCtrl( parent, ID_OPERATION_LIST, wxDefaultPosition, wxSize(160,200), wxLC_REPORT|wxSUNKEN_BORDER );
-    item7->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item7->Add(item9, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item10 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -792,14 +792,14 @@ FUDialog::createContents(wxWindow* parent, bool call_fit, bool set_sizer) {
     wxButton *item14 = new wxButton( parent, ID_ADD_OPERATION_FROM_OPSET, wxT(" Add from  Opset... "), wxDefaultPosition, wxDefaultSize, 0 );
     item7->Add( item14, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item7, 0, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item0->Add(item7, 0, wxGROW | wxALL, 5);
 
     wxStaticBox *item16 = new wxStaticBox( parent, -1, wxT("Ports:") );
     wxStaticBoxSizer *item15 = new wxStaticBoxSizer( item16, wxVERTICAL );
     portsSizer_ = item15;
 
     wxListCtrl *item17 = new wxListCtrl( parent, ID_PORT_LIST, wxDefaultPosition, wxSize(160,200), wxLC_REPORT|wxSUNKEN_BORDER );
-    item15->Add( item17, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item15->Add(item17, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item18 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -814,7 +814,7 @@ FUDialog::createContents(wxWindow* parent, bool call_fit, bool set_sizer) {
 
     item15->Add( item18, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item15, 0, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item0->Add(item15, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item25 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/FUDialog.cc
+++ b/tce/src/procgen/ProDe/FUDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of FUDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/FUDialog.cc
+++ b/tce/src/procgen/ProDe/FUDialog.cc
@@ -767,7 +767,7 @@ FUDialog::createContents(wxWindow* parent, bool call_fit, bool set_sizer) {
     wxChoice *item6 = new wxChoice( parent, ID_ADDRESS_SPACE, wxDefaultPosition, wxSize(150,-1), 0, strs6, 0 );
     item4->Add( item6, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxStaticBox *item8 = new wxStaticBox( parent, -1, wxT("Operations:") );
     wxStaticBoxSizer *item7 = new wxStaticBoxSizer( item8, wxVERTICAL );
@@ -790,7 +790,7 @@ FUDialog::createContents(wxWindow* parent, bool call_fit, bool set_sizer) {
     item7->Add( item10, 0, wxALIGN_CENTER, 5 );
 
     wxButton *item14 = new wxButton( parent, ID_ADD_OPERATION_FROM_OPSET, wxT(" Add from  Opset... "), wxDefaultPosition, wxDefaultSize, 0 );
-    item7->Add( item14, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item7->Add(item14, 0, wxALL, 5);
 
     item0->Add(item7, 0, wxGROW | wxALL, 5);
 
@@ -831,7 +831,7 @@ FUDialog::createContents(wxWindow* parent, bool call_fit, bool set_sizer) {
     wxButton *item29 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item27->Add( item29, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item27, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item27, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/FUGuardDialog.cc
+++ b/tce/src/procgen/ProDe/FUGuardDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of FUGuardDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/wx.h>

--- a/tce/src/procgen/ProDe/FUGuardDialog.cc
+++ b/tce/src/procgen/ProDe/FUGuardDialog.cc
@@ -341,7 +341,7 @@ FUGuardDialog::createContents(
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxCheckBox *item6 = new wxCheckBox( parent, ID_INVERTED, wxT("Inverted"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item6, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item6, 0, wxALL, 5);
 
     wxStaticLine *item7 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
     item0->Add(item7, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/FUGuardDialog.cc
+++ b/tce/src/procgen/ProDe/FUGuardDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of FUGuardDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/wx.h>
@@ -329,14 +329,14 @@ FUGuardDialog::createContents(
 
     wxString *strs3 = (wxString*) NULL;
     wxChoice *item3 = new wxChoice( parent, ID_FU_NAME, wxDefaultPosition, wxSize(100,-1), 0, strs3, 0 );
-    item1->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_PORT, wxT("Port Name:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item4, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_FU_PORT, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
@@ -344,7 +344,7 @@ FUGuardDialog::createContents(
     item0->Add( item6, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item7 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item7, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item8 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/FUPortDialog.cc
+++ b/tce/src/procgen/ProDe/FUPortDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of FUPortDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/FUPortDialog.cc
+++ b/tce/src/procgen/ProDe/FUPortDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of FUPortDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -423,7 +423,7 @@ FUPortDialog::createContents(
     item0->Add( item10, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item12 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-    item0->Add( item12, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item12, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item13 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/FUPortDialog.cc
+++ b/tce/src/procgen/ProDe/FUPortDialog.cc
@@ -390,7 +390,9 @@ FUPortDialog::createContents(
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item5 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(200,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item5 =
+        new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     item1->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_INPUT_SOCKET, wxT("Input Socket:"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/tce/src/procgen/ProDe/FUPortDialog.cc
+++ b/tce/src/procgen/ProDe/FUPortDialog.cc
@@ -382,19 +382,19 @@ FUPortDialog::createContents(
     wxFlexGridSizer *item1 = new wxFlexGridSizer( 2, 0, 0 );
 
     wxStaticText *item2 = new wxStaticText( parent, ID_LABEL_NAME, wxT("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item3 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(200,-1), 0 );
     item1->Add( item3, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item5 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(200,-1), 0, 1, 10000, 1 );
     item1->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_INPUT_SOCKET, wxT("Input Socket:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString strs7[] =
     {
@@ -404,7 +404,7 @@ FUPortDialog::createContents(
     item1->Add( item7, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_OUTPUT_SOCKET, wxT("Output Socket:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item8, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString strs9[] =
     {
@@ -420,7 +420,7 @@ FUPortDialog::createContents(
     wxCheckBox *item11 = new wxCheckBox( parent, ID_TRIGGERS, wxT("Triggers"), wxDefaultPosition, wxDefaultSize, 0 );
     item10->Add( item11, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item10, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item10, 0, wxALL, 5);
 
     wxStaticLine *item12 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
     item0->Add(item12, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/GCUDialog.cc
+++ b/tce/src/procgen/ProDe/GCUDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of GCUDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -851,27 +851,28 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     item3->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxTextCtrl *item5 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(140,-1), 0 );
-    item3->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item3->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_TEXT_DS, wxT("Delay slots:"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_DELAY_SLOTS, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 0, 10000, 1 );
-    item3->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item3->Add(item7, 0, wxGROW | wxALL, 5);
 
     // global guard latency currently fixed at 1.
     //wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_GLOBAL_GUARD_LATENCY, wxT("Guard Latency:"), wxDefaultPosition, wxDefaultSize, 0 );
     //item3->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    //wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_GUARD_LATENCY, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 1000, 0 );
-    //item3->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    // wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_GUARD_LATENCY, wxT("0"),
+    // wxDefaultPosition, wxSize(100,-1), 0, 0, 1000, 0 ); item3->Add( item9, 0,
+    // wxGROW|wxALL, 5 );
 
     wxStaticText *item10 = new wxStaticText( parent, ID_TEXT_AS, wxT("Address Space:"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item10, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxString *strs11 = (wxString*) NULL;
     wxChoice *item11 = new wxChoice( parent, ID_ADDRESS_SPACE, wxDefaultPosition, wxSize(100,-1), 0, strs11, 0 );
-    item3->Add( item11, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item3->Add(item11, 0, wxGROW | wxALL, 5);
 
     item2->Add( item3, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
@@ -880,7 +881,7 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     operationsSizer_ = item12;
 
     wxListCtrl *item14 = new wxListCtrl( parent, ID_OPERATION_LIST, wxDefaultPosition, wxSize(300,200), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item12->Add( item14, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item12->Add(item14, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item15 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -895,7 +896,7 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
 
     item12->Add( item15, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( item12, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item12, 0, wxGROW | wxALL, 5);
 
     item1->Add( item2, 0, wxGROW|wxALL, 5 );
 
@@ -906,7 +907,7 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxBoxSizer *item21 = new wxBoxSizer( wxVERTICAL );
 
     wxListCtrl *item22 = new wxListCtrl( parent, ID_PORT_LIST, wxDefaultPosition, wxSize(300,180), wxLC_REPORT|wxSUNKEN_BORDER );
-    item21->Add( item22, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item21->Add(item22, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item23 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -929,7 +930,7 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     item21->Add( item26, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticLine *item29 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item21->Add( item29, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item21->Add(item29, 0, wxGROW | wxALL, 5);
 
     wxFlexGridSizer *item30 = new wxFlexGridSizer( 2, 0, 0 );
 
@@ -943,19 +944,19 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxChoice *item32 = new wxChoice( parent, ID_RA_CHOICE, wxDefaultPosition, wxSize(120,-1), 1, strs32, 0 );
     item30->Add( item32, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item21->Add( item30, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item21->Add(item30, 0, wxGROW | wxALL, 5);
 
     wxStaticLine *item35 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item21->Add( item35, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item21->Add(item35, 0, wxGROW | wxALL, 5);
 
-    item19->Add( item21, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item19->Add(item21, 0, wxGROW | wxALL, 5);
 
-    item1->Add( item19, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item19, 0, wxGROW | wxALL, 5);
 
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticLine *item36 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item36, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item36, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item37 = new wxGridSizer( 2, 0, 0 );
 
@@ -972,7 +973,7 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
 
     item37->Add( item39, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item37, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT, 5 );
+    item0->Add(item37, 0, wxGROW | wxLEFT | wxRIGHT, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/GCUDialog.cc
+++ b/tce/src/procgen/ProDe/GCUDialog.cc
@@ -848,33 +848,34 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxFlexGridSizer *item3 = new wxFlexGridSizer( 2, 0, 0 );
 
     wxStaticText *item4 = new wxStaticText( parent, ID_TEXT_NAME, wxT("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item3->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item3->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item5 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(140,-1), 0 );
     item3->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_TEXT_DS, wxT("Delay slots:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item3->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item3->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_DELAY_SLOTS, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 0, 10000, 1 );
     item3->Add(item7, 0, wxGROW | wxALL, 5);
 
     // global guard latency currently fixed at 1.
-    //wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_GLOBAL_GUARD_LATENCY, wxT("Guard Latency:"), wxDefaultPosition, wxDefaultSize, 0 );
-    //item3->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    // wxStaticText *item8 = new wxStaticText( parent,
+    // ID_LABEL_GLOBAL_GUARD_LATENCY, wxT("Guard Latency:"), wxDefaultPosition,
+    // wxDefaultSize, 0 ); item3->Add( item8, 0, wxALIGN_RIGHT|wxALL, 5 );
 
     // wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_GUARD_LATENCY, wxT("0"),
     // wxDefaultPosition, wxSize(100,-1), 0, 0, 1000, 0 ); item3->Add( item9, 0,
     // wxGROW|wxALL, 5 );
 
     wxStaticText *item10 = new wxStaticText( parent, ID_TEXT_AS, wxT("Address Space:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item3->Add( item10, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item3->Add(item10, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs11 = (wxString*) NULL;
     wxChoice *item11 = new wxChoice( parent, ID_ADDRESS_SPACE, wxDefaultPosition, wxSize(100,-1), 0, strs11, 0 );
     item3->Add(item11, 0, wxGROW | wxALL, 5);
 
-    item2->Add( item3, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item3, 0, wxALL, 5);
 
     wxStaticBox *item13 = new wxStaticBox( parent, -1, wxT("Operations:") );
     wxStaticBoxSizer *item12 = new wxStaticBoxSizer( item13, wxVERTICAL );
@@ -917,7 +918,7 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxButton *item25 = new wxButton( parent, ID_DELETE_PORT, wxT("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
     item23->Add( item25, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item21->Add( item23, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
+    item21->Add(item23, 0, wxALIGN_RIGHT, 5);
 
     wxBoxSizer *item26 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -971,7 +972,7 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxButton *item41 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item39->Add( item41, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item37->Add( item39, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item37->Add(item39, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item37, 0, wxGROW | wxLEFT | wxRIGHT, 5);
 

--- a/tce/src/procgen/ProDe/GCUDialog.cc
+++ b/tce/src/procgen/ProDe/GCUDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of GCUDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/GCUDialog.cc
+++ b/tce/src/procgen/ProDe/GCUDialog.cc
@@ -856,7 +856,9 @@ GCUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxStaticText *item6 = new wxStaticText( parent, ID_TEXT_DS, wxT("Delay slots:"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_DELAY_SLOTS, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 0, 10000, 1 );
+    wxSpinCtrl *item7 =
+        new wxSpinCtrl(parent, ID_DELAY_SLOTS, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 0, 10000, 1);
     item3->Add(item7, 0, wxGROW | wxALL, 5);
 
     // global guard latency currently fixed at 1.

--- a/tce/src/procgen/ProDe/GenerateProcessorDialog.cc
+++ b/tce/src/procgen/ProDe/GenerateProcessorDialog.cc
@@ -427,8 +427,8 @@ GenerateProcessorDialog::createContents(
 
     wxRadioButton *verilog_item = new wxRadioButton( parent, ID_VERILOG, wxT("Verilog"), wxDefaultPosition, wxDefaultSize, 0 );
 
-    hdl_boxsizer->Add( vhdl_item, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-    hdl_boxsizer->Add( verilog_item, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    hdl_boxsizer->Add(vhdl_item, 0, wxALL, 5);
+    hdl_boxsizer->Add(verilog_item, 0, wxALL, 5);
     item1->Add(hdl_boxsizer, 0, wxGROW | wxALL, 5);
     //
 
@@ -437,7 +437,7 @@ GenerateProcessorDialog::createContents(
 
     wxRadioButton *item4 = new wxRadioButton( parent, ID_GENERATE_BEM, wxT("Generate new"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     item4->SetValue( TRUE );
-    item2->Add( item4, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item4, 0, wxALL, 5);
 
     wxBoxSizer *item5 = new wxBoxSizer( wxVERTICAL );
 
@@ -446,7 +446,7 @@ GenerateProcessorDialog::createContents(
     wxCheckBox *item7 = new wxCheckBox( parent, ID_SAVE_BEM, wxT("Save to file:"), wxDefaultPosition, wxDefaultSize, 0 );
     item6->Add( item7, 0, wxALIGN_CENTER_VERTICAL|wxLEFT, 5 );
 
-    item5->Add( item6, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item5->Add(item6, 0, wxALL, 5);
 
     wxBoxSizer *item8 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -456,12 +456,12 @@ GenerateProcessorDialog::createContents(
     wxButton *item10 = new wxButton( parent, ID_BROWSE_BEM_SAVE, wxT("Browse..."), wxDefaultPosition, wxDefaultSize, 0 );
     item8->Add( item10, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item5->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item5->Add(item8, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item2->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxRadioButton *item11 = new wxRadioButton( parent, ID_LOAD_BEM, wxT("Load from file"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item11, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item11, 0, wxALL, 5);
 
     wxBoxSizer *item12 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -471,7 +471,7 @@ GenerateProcessorDialog::createContents(
     wxButton *item14 = new wxButton( parent, ID_BROWSE_BEM_LOAD, wxT("Browse..."), wxDefaultPosition, wxDefaultSize, 0 );
     item12->Add( item14, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item12, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item1->Add(item2, 0, wxGROW | wxALL, 5);
 
@@ -488,7 +488,7 @@ GenerateProcessorDialog::createContents(
     wxButton *item19 = new wxButton( parent, ID_BROWSE_TARGET, wxT("Browse..."), wxDefaultPosition, wxDefaultSize, 0 );
     item17->Add( item19, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item15->Add( item17, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item15->Add(item17, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item1->Add(item15, 0, wxGROW | wxALL, 5);
 
@@ -503,7 +503,7 @@ GenerateProcessorDialog::createContents(
     wxButton *item23 = new wxButton( parent, wxID_OK, wxT("OK"), wxDefaultPosition, wxDefaultSize, 0 );
     item21->Add( item23, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item21, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item21, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item1, 0, wxGROW | wxALL, 5);
 

--- a/tce/src/procgen/ProDe/GenerateProcessorDialog.cc
+++ b/tce/src/procgen/ProDe/GenerateProcessorDialog.cc
@@ -26,9 +26,9 @@
  *
  * Implementation of GenerateProcessorDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @author Otto Esko 2008 (otto.esko-no.spam-tut.fi)
- * @author Pekka Jääskeläinen 2011
+ * @author Pekka Jï¿½ï¿½skelï¿½inen 2011
  * @author Vinogradov Viacheslav(added Verilog generating) 2012 
  * @note rating: red
  */
@@ -429,7 +429,7 @@ GenerateProcessorDialog::createContents(
 
     hdl_boxsizer->Add( vhdl_item, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
     hdl_boxsizer->Add( verilog_item, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-    item1->Add( hdl_boxsizer, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(hdl_boxsizer, 0, wxGROW | wxALL, 5);
     //
 
     wxStaticBox *item3 = new wxStaticBox( parent, -1, wxT("Binary Encoding Map:") );
@@ -458,7 +458,7 @@ GenerateProcessorDialog::createContents(
 
     item5->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item2->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxRadioButton *item11 = new wxRadioButton( parent, ID_LOAD_BEM, wxT("Load from file"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item11, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -473,7 +473,7 @@ GenerateProcessorDialog::createContents(
 
     item2->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item1->Add( item2, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxGROW | wxALL, 5);
 
     item1->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
@@ -490,10 +490,10 @@ GenerateProcessorDialog::createContents(
 
     item15->Add( item17, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item1->Add( item15, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item15, 0, wxGROW | wxALL, 5);
 
     wxStaticLine *item20 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item1->Add( item20, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item20, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item21 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -505,7 +505,7 @@ GenerateProcessorDialog::createContents(
 
     item1->Add( item21, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/GenerateProcessorDialog.cc
+++ b/tce/src/procgen/ProDe/GenerateProcessorDialog.cc
@@ -26,10 +26,10 @@
  *
  * Implementation of GenerateProcessorDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @author Otto Esko 2008 (otto.esko-no.spam-tut.fi)
- * @author Pekka J��skel�inen 2011
- * @author Vinogradov Viacheslav(added Verilog generating) 2012 
+ * @author Pekka Jääskeläinen 2011
+ * @author Vinogradov Viacheslav(added Verilog generating) 2012
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/IUDialog.cc
+++ b/tce/src/procgen/ProDe/IUDialog.cc
@@ -517,13 +517,17 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxStaticText *item5 = new wxStaticText( parent, ID_LABEL_SIZE, wxT("Size:"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add(item5, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item6 = new wxSpinCtrl( parent, ID_SIZE, wxT("1"), wxDefaultPosition, wxSize(60,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item6 =
+        new wxSpinCtrl(parent, ID_SIZE, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     item2->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item7 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add(item7, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item8 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item8 =
+        new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     item2->Add( item8, 0, wxGROW|wxALL, 5 );
 
     item1->Add( item2, 0, wxALIGN_CENTER_VERTICAL, 5 );

--- a/tce/src/procgen/ProDe/IUDialog.cc
+++ b/tce/src/procgen/ProDe/IUDialog.cc
@@ -509,19 +509,19 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxFlexGridSizer *item2 = new wxFlexGridSizer( 4, 0, 0 );
 
     wxStaticText *item3 = new wxStaticText( parent, ID_LABEL_NAME, wxT("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item3, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item3, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item4 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(120,-1), 0 );
     item2->Add(item4, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item5 = new wxStaticText( parent, ID_LABEL_SIZE, wxT("Size:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item5, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item5, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item6 = new wxSpinCtrl( parent, ID_SIZE, wxT("1"), wxDefaultPosition, wxSize(60,-1), 0, 1, 10000, 1 );
     item2->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item7 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item7, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item7, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item8 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
     item2->Add( item8, 0, wxGROW|wxALL, 5 );
@@ -567,7 +567,7 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
 
     item1->Add(item15, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxALL, 5);
 
     wxStaticLine *item22 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
     item0->Add(item22, 0, wxGROW | wxALL, 5);
@@ -585,7 +585,7 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxButton *item27 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item25->Add( item27, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item23->Add( item25, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item23->Add(item25, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item23, 0, wxGROW, 5);
 

--- a/tce/src/procgen/ProDe/IUDialog.cc
+++ b/tce/src/procgen/ProDe/IUDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of IUDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/valgen.h>

--- a/tce/src/procgen/ProDe/IUDialog.cc
+++ b/tce/src/procgen/ProDe/IUDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of IUDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/valgen.h>
@@ -512,13 +512,13 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     item2->Add( item3, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxTextCtrl *item4 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(120,-1), 0 );
-    item2->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item4, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item5 = new wxStaticText( parent, ID_LABEL_SIZE, wxT("Size:"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item5, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxSpinCtrl *item6 = new wxSpinCtrl( parent, ID_SIZE, wxT("1"), wxDefaultPosition, wxSize(60,-1), 0, 1, 10000, 1 );
-    item2->Add( item6, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item7 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item7, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -541,16 +541,16 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     templateListSizer_ = item12;
 
     wxListCtrl *item14 = new wxListCtrl( parent, ID_TEMPLATE_LIST, wxDefaultPosition, wxSize(200,200), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item12->Add( item14, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item12->Add(item14, 0, wxGROW | wxALL, 5);
 
-    item1->Add( item12, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item12, 0, wxGROW | wxALL, 5);
 
     wxStaticBox *item16 = new wxStaticBox( parent, -1, wxT("Ports:") );
     wxStaticBoxSizer *item15 = new wxStaticBoxSizer( item16, wxVERTICAL );
     portListSizer_ = item15;
 
     wxListCtrl *item17 = new wxListCtrl( parent, ID_PORT_LIST, wxDefaultPosition, wxSize(240,150), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item15->Add( item17, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item15->Add(item17, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item18 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -565,12 +565,12 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
 
     item15->Add( item18, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item15, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item15, 0, wxGROW | wxALL, 5);
 
     item0->Add( item1, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item22 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item22, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item22, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item23 = new wxGridSizer( 2, 0, 0 );
 
@@ -587,7 +587,7 @@ IUDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
 
     item23->Add( item25, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item23, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item23, 0, wxGROW, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/IUPortDialog.cc
+++ b/tce/src/procgen/ProDe/IUPortDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of IUPortDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <boost/format.hpp>
@@ -292,19 +292,19 @@ IUPortDialog::createContents(
     item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxTextCtrl *item3 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(140,-1), 0 );
-    item1->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_OUTPUT_SOCKET, wxT("Output Socket"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_OUTPUT_SOCKET, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxStaticLine *item6 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item6, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item7 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/IUPortDialog.cc
+++ b/tce/src/procgen/ProDe/IUPortDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of IUPortDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <boost/format.hpp>

--- a/tce/src/procgen/ProDe/IUPortDialog.cc
+++ b/tce/src/procgen/ProDe/IUPortDialog.cc
@@ -289,13 +289,13 @@ IUPortDialog::createContents(
     wxFlexGridSizer *item1 = new wxFlexGridSizer( 2, 0, 0 );
 
     wxStaticText *item2 = new wxStaticText( parent, ID_LABEL_NAME, wxT("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item3 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(140,-1), 0 );
     item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_OUTPUT_SOCKET, wxT("Output Socket"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_OUTPUT_SOCKET, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );

--- a/tce/src/procgen/ProDe/ImmediateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/ImmediateSlotDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of ImmediateSlotDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2005 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2005 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -280,7 +280,7 @@ ImmediateSlotDialog::createContents(
     wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
 
     wxListCtrl *item1 = new wxListCtrl( parent, ID_SLOT_LIST, wxDefaultPosition, wxSize(300,200), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item2 = new wxBoxSizer( wxVERTICAL );
 
@@ -294,7 +294,7 @@ ImmediateSlotDialog::createContents(
     wxTextCtrl *item6 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(120,-1), 0 );
     item4->Add( item6, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item3->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item3->Add(item4, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item7 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -308,10 +308,10 @@ ImmediateSlotDialog::createContents(
 
     item2->Add( item3, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item2, 0, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item0->Add(item2, 0, wxGROW | wxALL, 5);
 
     wxStaticLine *item10 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item10, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item11 = new wxGridSizer( 2, 0, 0 );
 
@@ -328,7 +328,7 @@ ImmediateSlotDialog::createContents(
 
     item11->Add( item13, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-    item0->Add( item11, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item11, 0, wxGROW, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/ImmediateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/ImmediateSlotDialog.cc
@@ -326,7 +326,7 @@ ImmediateSlotDialog::createContents(
     wxButton *item15 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item13->Add( item15, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item11->Add( item13, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
+    item11->Add(item13, 0, wxALIGN_RIGHT, 5);
 
     item0->Add(item11, 0, wxGROW, 5);
 

--- a/tce/src/procgen/ProDe/ImmediateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/ImmediateSlotDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of ImmediateSlotDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2005 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2005 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/MDFView.cc
+++ b/tce/src/procgen/ProDe/MDFView.cc
@@ -26,7 +26,7 @@
  *
  * Definition of MFDView class.
  *
- * @author Veli-Pekka J��skel�inen 2003 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2003 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  * @note reviewed Jun 23 2004 by ml, jn, jm, vpj
  */

--- a/tce/src/procgen/ProDe/MachineDialog.cc
+++ b/tce/src/procgen/ProDe/MachineDialog.cc
@@ -27,7 +27,7 @@
  * Implementation of MachineDialog class.
  *
  * Created on: 6.2.2015
- * @author: Henry Linjamäki (henry.linjamaki-no.spam-tut.fi)
+ * @author: Henry Linjamï¿½ki (henry.linjamaki-no.spam-tut.fi)
  * @note rating: red
  */
 
@@ -140,7 +140,7 @@ MachineDialog::createContents(
     // Buttons //
     wxStaticLine *horizLine = new wxStaticLine(parent, wxID_ANY,
         wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL);
-    root->Add(horizLine, 0, wxGROW|wxALIGN_CENTER|wxALL, 5);
+    root->Add(horizLine, 0, wxGROW | wxALL, 5);
     wxBoxSizer *buttonBox = new wxBoxSizer(wxHORIZONTAL);
     // Ok button
     wxButton *okButton =

--- a/tce/src/procgen/ProDe/MachineDialog.cc
+++ b/tce/src/procgen/ProDe/MachineDialog.cc
@@ -27,7 +27,7 @@
  * Implementation of MachineDialog class.
  *
  * Created on: 6.2.2015
- * @author: Henry Linjam�ki (henry.linjamaki-no.spam-tut.fi)
+ * @author: Linjamäki (henry.linjamaki-no.spam-tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/MachineDialog.cc
+++ b/tce/src/procgen/ProDe/MachineDialog.cc
@@ -27,7 +27,7 @@
  * Implementation of MachineDialog class.
  *
  * Created on: 6.2.2015
- * @author: Linjamäki (henry.linjamaki-no.spam-tut.fi)
+ * @author: Henry Linjamäki (henry.linjamaki-no.spam-tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/MachineDialog.cc
+++ b/tce/src/procgen/ProDe/MachineDialog.cc
@@ -127,8 +127,7 @@ MachineDialog::createContents(
     // Label
     wxStaticText *endianessLabel = new wxStaticText(parent, -1,
         wxT("Endianess:"), wxDefaultPosition, wxDefaultSize, 0 );
-    machSettings->Add(endianessLabel,
-        0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    machSettings->Add(endianessLabel, 0, wxALIGN_RIGHT | wxALL, 5);
     // Choice
     endianessChoise_ = new wxChoice(parent, ID_ENDIANESS_CHOICE,
         wxDefaultPosition, wxDefaultSize);

--- a/tce/src/procgen/ProDe/OperationDialog.cc
+++ b/tce/src/procgen/ProDe/OperationDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of OperationDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/OperationDialog.cc
+++ b/tce/src/procgen/ProDe/OperationDialog.cc
@@ -1129,14 +1129,14 @@ OperationDialog::createContents(
     wxBoxSizer *item11 = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *item12 = new wxStaticText( parent, ID_LABEL_PORT, wxT("Port:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item11->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item11->Add(item12, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs13 = (wxString*) NULL;
     wxChoice *item13 = new wxChoice( parent, ID_PORT, wxDefaultPosition, wxSize(100,-1), 0, strs13, 0 );
     item11->Add(item13, 0, wxGROW | wxALL, 5);
 
     wxButton *item14 = new wxButton( parent, ID_DELETE_OPERAND, wxT("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
-    item11->Add( item14, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item11->Add(item14, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item10->Add(item11, 0, wxGROW, 5);
 
@@ -1146,7 +1146,7 @@ OperationDialog::createContents(
     wxBoxSizer *item16 = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *item17 = new wxStaticText( parent, ID_LABEL_OPERAND, wxT("New operand:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item16->Add( item17, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item16->Add(item17, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item18 = new wxSpinCtrl( parent, ID_NUMBER, wxT("1"), wxDefaultPosition, wxSize(60,-1), 0, 1, 10000, 1 );
     item16->Add(item18, 0, wxGROW | wxALL, 5);
@@ -1247,7 +1247,7 @@ OperationDialog::createContents(
     wxButton *item44 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item42->Add( item44, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item40->Add( item42, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
+    item40->Add(item42, 0, wxALIGN_RIGHT, 5);
 
     item38->Add(item40, 0, wxGROW, 5);
 

--- a/tce/src/procgen/ProDe/OperationDialog.cc
+++ b/tce/src/procgen/ProDe/OperationDialog.cc
@@ -1129,14 +1129,14 @@ OperationDialog::createContents(
     wxBoxSizer *item11 = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *item12 = new wxStaticText( parent, ID_LABEL_PORT, wxT("Port:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item11->Add(item12, 0, wxALIGN_RIGHT | wxALL, 5);
+    item11->Add(item12, 0, wxALL, 5);
 
     wxString *strs13 = (wxString*) NULL;
     wxChoice *item13 = new wxChoice( parent, ID_PORT, wxDefaultPosition, wxSize(100,-1), 0, strs13, 0 );
     item11->Add(item13, 0, wxGROW | wxALL, 5);
 
     wxButton *item14 = new wxButton( parent, ID_DELETE_OPERAND, wxT("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
-    item11->Add(item14, 0, wxALIGN_RIGHT | wxALL, 5);
+    item11->Add(item14, 0, wxALL, 5);
 
     item10->Add(item11, 0, wxGROW, 5);
 
@@ -1146,7 +1146,7 @@ OperationDialog::createContents(
     wxBoxSizer *item16 = new wxBoxSizer( wxHORIZONTAL );
 
     wxStaticText *item17 = new wxStaticText( parent, ID_LABEL_OPERAND, wxT("New operand:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item16->Add(item17, 0, wxALIGN_RIGHT | wxALL, 5);
+    item16->Add(item17, 0, wxALL, 5);
 
     wxSpinCtrl *item18 =
         new wxSpinCtrl(parent, ID_NUMBER, wxT("1"), wxDefaultPosition,

--- a/tce/src/procgen/ProDe/OperationDialog.cc
+++ b/tce/src/procgen/ProDe/OperationDialog.cc
@@ -1148,7 +1148,9 @@ OperationDialog::createContents(
     wxStaticText *item17 = new wxStaticText( parent, ID_LABEL_OPERAND, wxT("New operand:"), wxDefaultPosition, wxDefaultSize, 0 );
     item16->Add(item17, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item18 = new wxSpinCtrl( parent, ID_NUMBER, wxT("1"), wxDefaultPosition, wxSize(60,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item18 =
+        new wxSpinCtrl(parent, ID_NUMBER, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     item16->Add(item18, 0, wxGROW | wxALL, 5);
 
     wxButton *item19 = new wxButton( parent, ID_ADD_OPERAND, wxT("Add"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/tce/src/procgen/ProDe/OperationDialog.cc
+++ b/tce/src/procgen/ProDe/OperationDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of OperationDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -1122,7 +1122,7 @@ OperationDialog::createContents(
     item8->AddGrowableRow( 0 );
 
     wxListCtrl *item9 = new wxListCtrl( parent, ID_BIND_LIST, wxDefaultPosition, wxSize(200,300), wxLC_REPORT|wxSUNKEN_BORDER );
-    item8->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item8->Add(item9, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item10 = new wxBoxSizer( wxVERTICAL );
 
@@ -1133,15 +1133,15 @@ OperationDialog::createContents(
 
     wxString *strs13 = (wxString*) NULL;
     wxChoice *item13 = new wxChoice( parent, ID_PORT, wxDefaultPosition, wxSize(100,-1), 0, strs13, 0 );
-    item11->Add( item13, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item11->Add(item13, 0, wxGROW | wxALL, 5);
 
     wxButton *item14 = new wxButton( parent, ID_DELETE_OPERAND, wxT("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
     item11->Add( item14, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item10->Add( item11, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item10->Add(item11, 0, wxGROW, 5);
 
     wxStaticLine *item15 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item10->Add( item15, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item10->Add(item15, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item16 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -1149,7 +1149,7 @@ OperationDialog::createContents(
     item16->Add( item17, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxSpinCtrl *item18 = new wxSpinCtrl( parent, ID_NUMBER, wxT("1"), wxDefaultPosition, wxSize(60,-1), 0, 1, 10000, 1 );
-    item16->Add( item18, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item16->Add(item18, 0, wxGROW | wxALL, 5);
 
     wxButton *item19 = new wxButton( parent, ID_ADD_OPERAND, wxT("Add"), wxDefaultPosition, wxDefaultSize, 0 );
     item16->Add( item19, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -1158,11 +1158,11 @@ OperationDialog::createContents(
 
     item8->Add( item10, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item6->Add( item8, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item6->Add(item8, 0, wxGROW, 5);
 
-    item2->Add( item6, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item2->Add(item6, 0, wxGROW, 5);
 
-    item1->Add( item2, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxGROW | wxALL, 5);
 
     wxFlexGridSizer *item20 = new wxFlexGridSizer( 1, 0, 0 );
     item20->AddGrowableCol( 0 );
@@ -1179,7 +1179,7 @@ OperationDialog::createContents(
 
     wxGrid *item24 = new wxGrid( parent, ID_RESOURCE_GRID, wxDefaultPosition, wxSize(400,200), wxWANTS_CHARS );
     item24->CreateGrid( 0, 0, wxGrid::wxGridSelectRows );
-    item23->Add( item24, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item23->Add(item24, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item25 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -1199,11 +1199,11 @@ OperationDialog::createContents(
 
     //item25->Add( 30, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item23->Add( item25, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item23->Add(item25, 0, wxGROW | wxALL, 5);
 
-    item21->Add( item23, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item21->Add(item23, 1, wxGROW, 5);
 
-    item20->Add( item21, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxBOTTOM, 5 );
+    item20->Add(item21, 0, wxGROW | wxBOTTOM, 5);
 
     wxStaticBox *item33 = new wxStaticBox( parent, -1, wxT("Operand usage:") );
     wxStaticBoxSizer *item32 = new wxStaticBoxSizer( item33, wxHORIZONTAL );
@@ -1213,7 +1213,7 @@ OperationDialog::createContents(
     item34->CreateGrid( 0, 0, wxGrid::wxGridSelectCells );
     item32->Add( item34, 1, wxGROW|wxALL, 5 );
 
-    item20->Add( item32, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item20->Add(item32, 0, wxGROW, 5);
 
     wxBoxSizer *item35 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -1223,16 +1223,16 @@ OperationDialog::createContents(
     wxStaticText *item37 = new wxStaticText( parent, ID_LATENCY, wxT("                 "), wxDefaultPosition, wxDefaultSize, 0 );
     item35->Add( item37, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item20->Add( item35, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item20->Add(item35, 0, wxGROW | wxALL, 5);
 
     item1->Add( item20, 0, wxGROW, 5 );
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item38 = new wxBoxSizer( wxVERTICAL );
 
     wxStaticLine *item39 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item38->Add( item39, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item38->Add(item39, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item40 = new wxGridSizer( 2, 0, 0 );
 
@@ -1249,9 +1249,9 @@ OperationDialog::createContents(
 
     item40->Add( item42, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-    item38->Add( item40, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item38->Add(item40, 0, wxGROW, 5);
 
-    item0->Add( item38, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item38, 0, wxGROW, 5);
 
     if (set_sizer) {
         parent->SetSizer( item0 );

--- a/tce/src/procgen/ProDe/OpsetDialog.cc
+++ b/tce/src/procgen/ProDe/OpsetDialog.cc
@@ -439,8 +439,9 @@ OpsetDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxStaticText *latencyLabel = new wxStaticText(parent, ID_TEXT,
         wxT("Latency:"), wxDefaultPosition, wxDefaultSize, 0);
     // Latency spinner
-    wxSpinCtrl *latencySpinner = new wxSpinCtrl(parent, ID_LATENCY, wxT("1"),
-        wxDefaultPosition, wxSize(50,-1), 0, 1, 100, 1);
+    wxSpinCtrl *latencySpinner =
+        new wxSpinCtrl(parent, ID_LATENCY, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 100, 1);
     latencySizer->Add(latencyLabel, 1, wxALIGN_CENTER_VERTICAL);
     latencySizer->Add(latencySpinner, 1);
     leftSizer->Add(latencySizer, 0, wxEXPAND|wxALL, 5);

--- a/tce/src/procgen/ProDe/OpsetDialog.cc
+++ b/tce/src/procgen/ProDe/OpsetDialog.cc
@@ -430,7 +430,7 @@ OpsetDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxTextCtrl *opNameFilter = new wxTextCtrl(parent, ID_OP_FILTER, wxT(""),
         wxDefaultPosition, wxDefaultSize, 0);
     filterSizer->Add(opNameFilterLabel, 0, wxALIGN_CENTER_VERTICAL);
-    filterSizer->Add(opNameFilter, 1, wxEXPAND|wxALIGN_RIGHT);
+    filterSizer->Add(opNameFilter, 1, wxEXPAND);
     leftSizer->Add(filterSizer, 0, wxEXPAND|wxALL, 5);
 
     // Sizer for latencyLabel and latencySpinner

--- a/tce/src/procgen/ProDe/OpsetDialog.cc
+++ b/tce/src/procgen/ProDe/OpsetDialog.cc
@@ -487,7 +487,7 @@ OpsetDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
         wxDefaultPosition, wxDefaultSize, 0);
     buttonsSizer->Add(okButton, 0, wxALIGN_CENTER|wxALL, 5);
 
-    mainSizer->Add(buttonsSizer, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    mainSizer->Add(buttonsSizer, 0, wxALIGN_RIGHT, 5);
 
     if (set_sizer) {
         parent->SetSizer(mainSizer);

--- a/tce/src/procgen/ProDe/PrintCmd.cc
+++ b/tce/src/procgen/ProDe/PrintCmd.cc
@@ -26,7 +26,7 @@
  *
  * Definition of PrintCmd class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/docview.h>

--- a/tce/src/procgen/ProDe/PrintPreviewCmd.cc
+++ b/tce/src/procgen/ProDe/PrintPreviewCmd.cc
@@ -26,7 +26,7 @@
  *
  * Definition of PrintPreviewCmd class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/docview.h>

--- a/tce/src/procgen/ProDe/ProDe.cc
+++ b/tce/src/procgen/ProDe/ProDe.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of the ProDe class.
  *
- * @author Veli-Pekka J��skel�inen (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/ProDe.cc
+++ b/tce/src/procgen/ProDe/ProDe.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of the ProDe class.
  *
- * @author Veli-Pekka Jääskeläinen (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -145,7 +145,7 @@ ProDe::OnInit() {
     commandRegistry_ = new CommandRegistry();
 
     // load image handler for pngs
-    wxImage::AddHandler(new wxPNGHandler);
+    wxImage::AddHandler(new wxPNGHandler());
 
     // set configurations
     string configFile = Environment::confPath("ProDe.conf");

--- a/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
+++ b/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
@@ -222,7 +222,7 @@ ProDeBusOrderDialog::createContents(
     wxButton *item9 = new wxButton( parent, wxID_OK, wxT("&OK"), wxDefaultPosition, wxDefaultSize, 0 );
     item7->Add( item9, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item0->Add( item7, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item7, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
+++ b/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
@@ -207,7 +207,7 @@ ProDeBusOrderDialog::createContents(
     wxButton *item5 = new wxButton( parent, ID_DOWN, wxT("&Down"), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item3, 0, wxALIGN_BOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item1->Add(item3, 0, wxALIGN_BOTTOM | wxALL, 5);
 
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 

--- a/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
+++ b/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of ProDeBusOrderDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2005 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2005 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -212,7 +212,7 @@ ProDeBusOrderDialog::createContents(
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticLine *item6 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item6, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item6, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item7 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
+++ b/tce/src/procgen/ProDe/ProDeBusOrderDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of ProDeBusOrderDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2005 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2005 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/ProDeOptionsDialog.cc
+++ b/tce/src/procgen/ProDe/ProDeOptionsDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of ProDeOptionsDialog class.
  *
- * @author Veli-Pekka Jääskeläinen (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka JÃ¤Ã¤skelÃ¤inen (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -140,7 +140,9 @@ ProDeOptionsDialog::createGeneralPage(
     wxStaticText *item1 = new wxStaticText( parent, ID_LABEL_UNDO_LEVELS, wxT("Undo levels:"), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    wxSpinCtrl *item2 = new wxSpinCtrl( parent, ID_UNDO_LEVELS, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 100, 0 );
+    wxSpinCtrl *item2 =
+        new wxSpinCtrl(parent, ID_UNDO_LEVELS, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 100, 0);
     item0->Add( item2, 0, wxALIGN_CENTER|wxALL, 5 );
 
     if (set_sizer)

--- a/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
+++ b/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
@@ -1122,7 +1122,7 @@ wxSizer *ProcessorImplementationWindow::registerFilePage( wxWindow *parent, bool
     buttonSizer->Add(autoSelButton, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_SELECT_RF_IMPL, wxT("Select implementation..."), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
+    buttonSizer->Add(item2, 0, wxALL, 5);
 
     item0->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 5);
 
@@ -1147,10 +1147,10 @@ wxSizer *ProcessorImplementationWindow::functionUnitPage( wxWindow *parent, bool
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add(autoSelButton, 0, wxALIGN_RIGHT | wxALL, 5);
+    buttonSizer->Add(autoSelButton, 0, wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_SELECT_FU_IMPL, wxT("Select implementation..."), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
+    buttonSizer->Add(item2, 0, wxALL, 5);
 
     item0->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 5);
 
@@ -1297,10 +1297,10 @@ wxSizer *ProcessorImplementationWindow::immediateUnitPage( wxWindow *parent, boo
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add(autoSelButton, 0, wxALIGN_RIGHT | wxALL, 5);
+    buttonSizer->Add(autoSelButton, 0, wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_SELECT_IU_IMPL, wxT("Select implementation..."), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
+    buttonSizer->Add(item2, 0, wxALL, 5);
 
     item0->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 5);
 

--- a/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
+++ b/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
@@ -26,8 +26,8 @@
  *
  * Implementation of ProcessorImplementationWindow class.
  *
- * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
- * @author Pekka Jääskeläinen 2021
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Pekka Jï¿½ï¿½skelï¿½inen 2021
  * @note rating: red
  */
 
@@ -1069,10 +1069,10 @@ wxSizer *ProcessorImplementationWindow::createContents( wxWindow *parent, bool c
     ProcessorImplementationWindow::icDecoderPluginPage( item7, FALSE );
     item2->AddPage( item7, wxT("IC / Decoder Plugin") );
 
-    item0->Add( item1, 0, wxFIXED_MINSIZE|wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxFIXED_MINSIZE | wxGROW | wxALL, 5);
 
     wxStaticLine *item8 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(200,-1), wxLI_HORIZONTAL );
-    item0->Add( item8, 0, wxFIXED_MINSIZE|wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item8, 0, wxFIXED_MINSIZE | wxGROW | wxALL, 5);
 
     wxGridSizer *item9 = new wxGridSizer( 2, 0, 0 );
 
@@ -1096,7 +1096,7 @@ wxSizer *ProcessorImplementationWindow::createContents( wxWindow *parent, bool c
 
     item9->Add( item14, 0, wxFIXED_MINSIZE|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-    item0->Add( item9, 0, wxFIXED_MINSIZE|wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item9, 0, wxFIXED_MINSIZE | wxGROW | wxALL, 5);
 
     if (set_sizer)
     {
@@ -1115,7 +1115,7 @@ wxSizer *ProcessorImplementationWindow::registerFilePage( wxWindow *parent, bool
     item0->AddGrowableRow( 0 );
 
     wxListCtrl *item1 = new wxListCtrl( parent, ID_RF_LIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1143,7 +1143,7 @@ wxSizer *ProcessorImplementationWindow::functionUnitPage( wxWindow *parent, bool
     item0->AddGrowableRow( 0 );
 
     wxListCtrl *item1 = new wxListCtrl( parent, ID_FU_LIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1187,9 +1187,9 @@ wxSizer *ProcessorImplementationWindow::decompressionPage( wxWindow *parent, boo
     wxButton *item6 = new wxButton( parent, ID_BROWSE_DECOMPRESSOR, wxT("Browse..."), wxDefaultPosition, wxDefaultSize, 0 );
     item3->Add( item6, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item3, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     item0->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
@@ -1219,7 +1219,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     item2->Add( item3, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxTextCtrl *item4 = new wxTextCtrl( parent, ID_IC_DEC_PLUGIN_FILE, wxT(""), wxDefaultPosition, wxSize(80,-1), wxTE_READONLY );
-    item2->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item4, 0, wxGROW | wxALL, 5);
 
     wxButton *item5 = new wxButton( parent, ID_BROWSE_IC_DEC_PLUGIN, wxT("Browse..."), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
@@ -1228,7 +1228,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     item2->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxTextCtrl *item7 = new wxTextCtrl( parent, ID_IC_DEC_HDB_FILE, wxT(""), wxDefaultPosition, wxSize(80,-1), 0 );
-    item2->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item7, 0, wxGROW | wxALL, 5);
 
     wxButton *item8 = new wxButton( parent, ID_BROWSE_IC_DEC_HDB, wxT("Browse..."), wxDefaultPosition, wxDefaultSize, 0 );
     item2->Add( item8, 0, wxALIGN_CENTER|wxALL, 5 );
@@ -1237,7 +1237,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     item2->Add( item9, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxTextCtrl *item10 = new wxTextCtrl( parent, ID_IC_DEC_PLUGIN_NAME, wxT(""), wxDefaultPosition, wxSize(80,-1), wxTE_READONLY );
-    item2->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item10, 0, wxGROW | wxALL, 5);
 
     item2->Add( 20, 20, 0, wxALIGN_CENTER|wxALL, 5 );
 
@@ -1247,7 +1247,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     wxTextCtrl *item12 = new wxTextCtrl( parent, ID_IC_DEC_PLUGIN_DESC, wxT(""), wxDefaultPosition, wxSize(320,80), wxTE_MULTILINE|wxTE_READONLY );
     item2->Add( item12, 0, wxGROW|wxALL, 5 );
 
-    item1->Add( item2, 0, wxFIXED_MINSIZE|wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxFIXED_MINSIZE | wxGROW | wxALL, 5);
 
     wxFlexGridSizer *item13 = new wxFlexGridSizer( 1, 0, 0 );
     item13->AddGrowableCol( 0 );
@@ -1257,7 +1257,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     item13->Add( item14, 0, wxALL, 5 );
 
     wxListCtrl *item15 = new wxListCtrl( parent, ID_PARAMETER_LIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item13->Add( item15, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item13->Add(item15, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item16 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -1272,9 +1272,9 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
 
     item13->Add( item16, 0, wxALIGN_CENTER, 5 );
 
-    item1->Add( item13, 0, wxFIXED_MINSIZE|wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item13, 0, wxFIXED_MINSIZE | wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     if (set_sizer)
     {
@@ -1293,7 +1293,7 @@ wxSizer *ProcessorImplementationWindow::immediateUnitPage( wxWindow *parent, boo
     item0->AddGrowableRow( 0 );
 
     wxListCtrl *item1 = new wxListCtrl( parent, ID_IU_LIST, wxDefaultPosition, wxDefaultSize, wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
+++ b/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
@@ -26,8 +26,8 @@
  *
  * Implementation of ProcessorImplementationWindow class.
  *
- * @author Veli-Pekka J��skel�inen 2006 (vjaaskel-no.spam-cs.tut.fi)
- * @author Pekka J��skel�inen 2021
+ * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Pekka Jääskeläinen 2021
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
+++ b/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
@@ -1094,7 +1094,7 @@ wxSizer *ProcessorImplementationWindow::createContents( wxWindow *parent, bool c
     wxButton *item15 = new wxButton( parent, ID_CLOSE, wxT("Close"), wxDefaultPosition, wxDefaultSize, 0 );
     item14->Add( item15, 0, wxFIXED_MINSIZE|wxALIGN_CENTER|wxALL, 5 );
 
-    item9->Add( item14, 0, wxFIXED_MINSIZE|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
+    item9->Add(item14, 0, wxFIXED_MINSIZE | wxALIGN_RIGHT, 5);
 
     item0->Add(item9, 0, wxFIXED_MINSIZE | wxGROW | wxALL, 5);
 
@@ -1119,12 +1119,12 @@ wxSizer *ProcessorImplementationWindow::registerFilePage( wxWindow *parent, bool
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add( autoSelButton, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    buttonSizer->Add(autoSelButton, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_SELECT_RF_IMPL, wxT("Select implementation..."), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    buttonSizer->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    item0->Add( buttonSizer, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {
@@ -1147,12 +1147,12 @@ wxSizer *ProcessorImplementationWindow::functionUnitPage( wxWindow *parent, bool
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add( autoSelButton, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    buttonSizer->Add(autoSelButton, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_SELECT_FU_IMPL, wxT("Select implementation..."), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    buttonSizer->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    item0->Add( buttonSizer, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {
@@ -1216,7 +1216,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     wxFlexGridSizer *item2 = new wxFlexGridSizer( 3, 0, 0 );
 
     wxStaticText *item3 = new wxStaticText( parent, ID_TEXT, wxT("Plugin file:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item3, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item3, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item4 = new wxTextCtrl( parent, ID_IC_DEC_PLUGIN_FILE, wxT(""), wxDefaultPosition, wxSize(80,-1), wxTE_READONLY );
     item2->Add(item4, 0, wxGROW | wxALL, 5);
@@ -1225,7 +1225,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     item2->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item6 = new wxStaticText( parent, ID_TEXT, wxT("HDB file:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item7 = new wxTextCtrl( parent, ID_IC_DEC_HDB_FILE, wxT(""), wxDefaultPosition, wxSize(80,-1), 0 );
     item2->Add(item7, 0, wxGROW | wxALL, 5);
@@ -1234,7 +1234,7 @@ wxSizer *ProcessorImplementationWindow::icDecoderPluginPage( wxWindow *parent, b
     item2->Add( item8, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item9 = new wxStaticText( parent, ID_TEXT, wxT("Plugin name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item9, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item9, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item10 = new wxTextCtrl( parent, ID_IC_DEC_PLUGIN_NAME, wxT(""), wxDefaultPosition, wxSize(80,-1), wxTE_READONLY );
     item2->Add(item10, 0, wxGROW | wxALL, 5);
@@ -1297,12 +1297,12 @@ wxSizer *ProcessorImplementationWindow::immediateUnitPage( wxWindow *parent, boo
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add( autoSelButton, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    buttonSizer->Add(autoSelButton, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_SELECT_IU_IMPL, wxT("Select implementation..."), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    buttonSizer->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    item0->Add( buttonSizer, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(buttonSizer, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
+++ b/tce/src/procgen/ProDe/ProcessorImplementationWindow.cc
@@ -1119,7 +1119,7 @@ wxSizer *ProcessorImplementationWindow::registerFilePage( wxWindow *parent, bool
 
     wxBoxSizer *buttonSizer = new wxBoxSizer( wxHORIZONTAL );
     wxButton *autoSelButton = new wxButton( parent, ID_AUTO_SELECT_IMPL, wxT("Auto Select Implementations"), wxDefaultPosition, wxDefaultSize, 0 );
-    buttonSizer->Add(autoSelButton, 0, wxALIGN_RIGHT | wxALL, 5);
+    buttonSizer->Add(autoSelButton, 0, wxALL, 5);
 
     wxButton *item2 = new wxButton( parent, ID_SELECT_RF_IMPL, wxT("Select implementation..."), wxDefaultPosition, wxDefaultSize, 0 );
     buttonSizer->Add(item2, 0, wxALL, 5);

--- a/tce/src/procgen/ProDe/RFDialog.cc
+++ b/tce/src/procgen/ProDe/RFDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of RFDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -535,53 +535,53 @@ RFDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxTextCtrl *item3 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(200,-1), 0 );
-    item1->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_TYPE, wxT("Type:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_TYPE, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_SIZE, wxT("Size:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_SIZE, wxT("1"), wxDefaultPosition, wxSize(120,-1), 0, 1, 10000, 1 );
-    item1->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item7, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
-    item1->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item9, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item10 = new wxStaticText( parent, ID_LABEL_MAX_READS, wxT("Max-Reads:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item10, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticText *item11 = new wxStaticText( parent, ID_MAX_READS, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0);
-    item1->Add( item11, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item11, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item12 = new wxStaticText( parent, ID_LABEL_MAX_WRITES, wxT("Max-Writes:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticText *item13 = new wxStaticText( parent, ID_MAX_WRITES, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0);
-    item1->Add( item13, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item13, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item14 = new wxStaticText( parent, ID_LABEL_GUARD_LATENCY, wxT("Guard Latency:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item14, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxSpinCtrl *item15 = new wxSpinCtrl( parent, ID_GUARD_LATENCY, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 1, 0 );
-    item1->Add( item15, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item15, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxStaticBox *item17 = new wxStaticBox( parent, -1, wxT("Ports:") );
     wxStaticBoxSizer *item16 = new wxStaticBoxSizer( item17, wxVERTICAL );
     portsSizer_ = item16;
 
     wxListCtrl *item18 = new wxListCtrl( parent, ID_PORT_LIST, wxDefaultPosition, wxSize(160,120), wxLC_REPORT|wxSUNKEN_BORDER );
-    item16->Add( item18, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item16->Add(item18, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item19 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/RFDialog.cc
+++ b/tce/src/procgen/ProDe/RFDialog.cc
@@ -547,13 +547,17 @@ RFDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_SIZE, wxT("Size:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_SIZE, wxT("1"), wxDefaultPosition, wxSize(120,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item7 =
+        new wxSpinCtrl(parent, ID_SIZE, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     item1->Add(item7, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add(item8, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item9 =
+        new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     item1->Add(item9, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item10 = new wxStaticText( parent, ID_LABEL_MAX_READS, wxT("Max-Reads:"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -571,7 +575,9 @@ RFDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxStaticText *item14 = new wxStaticText( parent, ID_LABEL_GUARD_LATENCY, wxT("Guard Latency:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add(item14, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item15 = new wxSpinCtrl( parent, ID_GUARD_LATENCY, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 1, 0 );
+    wxSpinCtrl *item15 =
+        new wxSpinCtrl(parent, ID_GUARD_LATENCY, wxT("0"), wxDefaultPosition,
+                       wxDefaultSize, 0, 0, 1, 0);
     item1->Add(item15, 0, wxGROW | wxALL, 5);
 
     item0->Add(item1, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/RFDialog.cc
+++ b/tce/src/procgen/ProDe/RFDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of RFDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/RFDialog.cc
+++ b/tce/src/procgen/ProDe/RFDialog.cc
@@ -532,44 +532,44 @@ RFDialog::createContents(wxWindow *parent, bool call_fit, bool set_sizer) {
     wxFlexGridSizer *item1 = new wxFlexGridSizer( 2, 0, 0 );
 
     wxStaticText *item2 = new wxStaticText( parent, ID_LABEL_NAME, wxT("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item3 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(200,-1), 0 );
     item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_TYPE, wxT("Type:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_TYPE, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );
     item1->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_SIZE, wxT("Size:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_SIZE, wxT("1"), wxDefaultPosition, wxSize(120,-1), 0, 1, 10000, 1 );
     item1->Add(item7, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item8, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item9 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
     item1->Add(item9, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item10 = new wxStaticText( parent, ID_LABEL_MAX_READS, wxT("Max-Reads:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item10, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item10, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxStaticText *item11 = new wxStaticText( parent, ID_MAX_READS, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0);
     item1->Add(item11, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item12 = new wxStaticText( parent, ID_LABEL_MAX_WRITES, wxT("Max-Writes:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item12, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxStaticText *item13 = new wxStaticText( parent, ID_MAX_WRITES, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0);
     item1->Add(item13, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item14 = new wxStaticText( parent, ID_LABEL_GUARD_LATENCY, wxT("Guard Latency:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item14, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item14, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item15 = new wxSpinCtrl( parent, ID_GUARD_LATENCY, wxT("0"), wxDefaultPosition, wxSize(100,-1), 0, 0, 1, 0 );
     item1->Add(item15, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/RFGuardDialog.cc
+++ b/tce/src/procgen/ProDe/RFGuardDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of RFGuardDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/wx.h>

--- a/tce/src/procgen/ProDe/RFGuardDialog.cc
+++ b/tce/src/procgen/ProDe/RFGuardDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of RFGuardDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  */
 
 #include <wx/wx.h>
@@ -356,22 +356,22 @@ RFGuardDialog::createContents(
 
     wxString *strs3 = (wxString*) NULL;
     wxChoice *item3 = new wxChoice( parent, ID_RF_NAME, wxDefaultPosition, wxSize(100,-1), 0, strs3, 0 );
-    item1->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_INDEX, wxT("Register Index:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item4, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_RF_INDEX, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxCheckBox *item6 = new wxCheckBox( parent, ID_INVERTED, wxT("Inverted"), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item6, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxStaticLine *item7 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item7, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item8 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/RFGuardDialog.cc
+++ b/tce/src/procgen/ProDe/RFGuardDialog.cc
@@ -368,7 +368,7 @@ RFGuardDialog::createContents(
     item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxCheckBox *item6 = new wxCheckBox( parent, ID_INVERTED, wxT("Inverted"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item6, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item6, 0, wxALL, 5);
 
     wxStaticLine *item7 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
     item0->Add(item7, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/RFPortDialog.cc
+++ b/tce/src/procgen/ProDe/RFPortDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of RFPortDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -363,8 +363,7 @@ RFPortDialog::createContents(
     inputSocketChoice_ =
 	new wxChoice(parent, ID_INPUT_SOCKET, wxDefaultPosition,
 		     wxSize(100,-1), 0, strs5, 0);
-    item1->Add( inputSocketChoice_, 0,
-                wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(inputSocketChoice_, 0, wxGROW | wxALL, 5);
 
     // output socket element
     wxStaticText *item6 =
@@ -375,13 +374,12 @@ RFPortDialog::createContents(
     outputSocketChoice_ =
 	new wxChoice(parent, ID_OUTPUT_SOCKET, wxDefaultPosition,
 		     wxSize(100,-1), 0, strs7, 0);
-    item1->Add( outputSocketChoice_, 0,
-                wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(outputSocketChoice_, 0, wxGROW | wxALL, 5);
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
     wxStaticLine *item8 =
 	new wxStaticLine(parent, -1, wxDefaultPosition, wxSize(20,-1),
 			 wxLI_HORIZONTAL);
-    item0->Add( item8, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item8, 0, wxGROW | wxALL, 5);
     wxBoxSizer *item9 = new wxBoxSizer( wxHORIZONTAL );
 
     // buttons

--- a/tce/src/procgen/ProDe/RFPortDialog.cc
+++ b/tce/src/procgen/ProDe/RFPortDialog.cc
@@ -347,7 +347,7 @@ RFPortDialog::createContents(
     wxStaticText *item2 =
 	new wxStaticText( parent, -1, wxT("Name:"),
 			  wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
     wxTextCtrl *item3 =
 	new wxTextCtrl(parent, ID_NAME, wxT(""), wxDefaultPosition,
 		       wxSize(160,-1), 0,
@@ -358,7 +358,7 @@ RFPortDialog::createContents(
     wxStaticText *item4 =
 	new wxStaticText(parent, -1, wxT("Input Socket:"),
 			 wxDefaultPosition, wxDefaultSize, 0);
-    item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
     wxString *strs5 = (wxString*) NULL;
     inputSocketChoice_ =
 	new wxChoice(parent, ID_INPUT_SOCKET, wxDefaultPosition,
@@ -369,7 +369,7 @@ RFPortDialog::createContents(
     wxStaticText *item6 =
 	new wxStaticText(parent, -1, wxT("Output Socket:"),
 			 wxDefaultPosition, wxDefaultSize, 0);
-    item1->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
     wxString *strs7 = (wxString*) NULL;
     outputSocketChoice_ =
 	new wxChoice(parent, ID_OUTPUT_SOCKET, wxDefaultPosition,

--- a/tce/src/procgen/ProDe/RFPortDialog.cc
+++ b/tce/src/procgen/ProDe/RFPortDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of RFPortDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/SRPortDialog.cc
+++ b/tce/src/procgen/ProDe/SRPortDialog.cc
@@ -26,8 +26,8 @@
  *
  * Definition of SRPortDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2005 (vjaaskel-no.spam-cs.tut.fi)
- * @author Pekka Jääskeläinen 2021
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2005 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Pekka Jï¿½ï¿½skelï¿½inen 2021
  * @note rating: red
  */
 
@@ -420,7 +420,7 @@ SRPortDialog::createContents(
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticLine *item10 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-    item0->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item10, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item11 = new wxBoxSizer( wxHORIZONTAL );
 

--- a/tce/src/procgen/ProDe/SRPortDialog.cc
+++ b/tce/src/procgen/ProDe/SRPortDialog.cc
@@ -386,19 +386,19 @@ SRPortDialog::createContents(
     wxFlexGridSizer *item1 = new wxFlexGridSizer( 2, 0, 0 );
 
     wxStaticText *item2 = new wxStaticText( parent, ID_LABEL_NAME, wxT("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxTextCtrl *item3 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(200,-1), 0 );
     item1->Add( item3, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item5 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(200,-1), 0, 1, 10000, 1 );
     item1->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_INPUT_SOCKET, wxT("Input Socket:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString strs7[] =
     {
@@ -408,7 +408,7 @@ SRPortDialog::createContents(
     item1->Add( item7, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item8 = new wxStaticText( parent, ID_LABEL_OUTPUT_SOCKET, wxT("Output Socket:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item8, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item8, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString strs9[] =
     {

--- a/tce/src/procgen/ProDe/SRPortDialog.cc
+++ b/tce/src/procgen/ProDe/SRPortDialog.cc
@@ -394,7 +394,9 @@ SRPortDialog::createContents(
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item5 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(200,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item5 =
+        new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition,
+                       wxDefaultSize, 0, 1, 10000, 1);
     item1->Add( item5, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_INPUT_SOCKET, wxT("Input Socket:"), wxDefaultPosition, wxDefaultSize, 0 );

--- a/tce/src/procgen/ProDe/SRPortDialog.cc
+++ b/tce/src/procgen/ProDe/SRPortDialog.cc
@@ -26,8 +26,8 @@
  *
  * Definition of SRPortDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2005 (vjaaskel-no.spam-cs.tut.fi)
- * @author Pekka J��skel�inen 2021
+ * @author Veli-Pekka Jääskeläinen 2005 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Pekka Jääskeläinen 2021
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/SocketDialog.cc
+++ b/tce/src/procgen/ProDe/SocketDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of SocketDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/SocketDialog.cc
+++ b/tce/src/procgen/ProDe/SocketDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of SocketDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -579,7 +579,7 @@ SocketDialog::createContents(
     wxTextCtrl *item4 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(120,-1), 0 );
     item2->Add( item4, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item2, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxGROW | wxALL, 5);
 
     wxString strs5[] =
     {
@@ -587,9 +587,9 @@ SocketDialog::createContents(
         wxT("Output")
     };
     wxRadioBox *item5 = new wxRadioBox( parent, ID_DIRECTION, wxT("Direction:"), wxDefaultPosition, wxDefaultSize, 2, strs5, 1, wxRA_SPECIFY_COLS );
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item6 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -624,7 +624,7 @@ SocketDialog::createContents(
     item0->Add( item6, 0, wxALIGN_CENTER, 5 );
 
     wxStaticLine *item16 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item16, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item16, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item17 = new wxGridSizer( 2, 0, 0 );
 
@@ -641,7 +641,7 @@ SocketDialog::createContents(
 
     item17->Add( item19, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item17, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item17, 0, wxGROW | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/SocketDialog.cc
+++ b/tce/src/procgen/ProDe/SocketDialog.cc
@@ -639,7 +639,7 @@ SocketDialog::createContents(
     wxButton *item21 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item19->Add( item21, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item17->Add( item19, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item17->Add(item19, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item17, 0, wxGROW | wxALL, 5);
 

--- a/tce/src/procgen/ProDe/TemplateListDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateListDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of TemplateListDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -514,7 +514,7 @@ TemplateListDialog::createContents(
     templateSizer_ = item2;
 
     wxListCtrl *item4 = new wxListCtrl( parent, ID_TEMPLATE_LIST, wxDefaultPosition, wxSize(160,200), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item2->Add( item4, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item4, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item5 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -524,7 +524,7 @@ TemplateListDialog::createContents(
     wxTextCtrl *item7 = new wxTextCtrl( parent, ID_NAME, wxT(""), wxDefaultPosition, wxSize(120,-1), 0 );
     item5->Add( item7, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item2->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item8 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -536,14 +536,14 @@ TemplateListDialog::createContents(
 
     item2->Add( item8, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item2, 0, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item1->Add(item2, 0, wxGROW | wxALL, 5);
 
     wxStaticBox *item12 = new wxStaticBox( parent, -1, wxT("Template Slots:") );
     wxStaticBoxSizer *item11 = new wxStaticBoxSizer( item12, wxVERTICAL );
     slotSizer_ = item11;
 
     wxListCtrl *item13 = new wxListCtrl( parent, ID_SLOT_LIST, wxDefaultPosition, wxSize(250,245), wxLC_REPORT|wxLC_SINGLE_SEL|wxSUNKEN_BORDER );
-    item11->Add( item13, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item11->Add(item13, 0, wxGROW | wxALL, 5);
 
     wxBoxSizer *item14 = new wxBoxSizer( wxHORIZONTAL );
 
@@ -558,12 +558,12 @@ TemplateListDialog::createContents(
 
     item11->Add( item14, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item1->Add( item11, 0, wxGROW|wxALIGN_CENTER_HORIZONTAL|wxALL, 5 );
+    item1->Add(item11, 0, wxGROW | wxALL, 5);
 
     item0->Add( item1, 0, wxALIGN_CENTER|wxALL, 5 );
 
     wxStaticLine *item18 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item18, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item18, 0, wxGROW | wxALL, 5);
 
     wxGridSizer *item19 = new wxGridSizer( 2, 0, 0 );
 
@@ -580,7 +580,7 @@ TemplateListDialog::createContents(
 
     item19->Add( item21, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item19, 0, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
+    item0->Add(item19, 0, wxGROW, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/TemplateListDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateListDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of TemplateListDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/TemplateListDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateListDialog.cc
@@ -578,7 +578,7 @@ TemplateListDialog::createContents(
     wxButton *item23 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item21->Add( item23, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item19->Add( item21, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item19->Add(item21, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item0->Add(item19, 0, wxGROW, 5);
 

--- a/tce/src/procgen/ProDe/TemplateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateSlotDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of TemplateSlotDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/TemplateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateSlotDialog.cc
@@ -26,7 +26,7 @@
  *
  * Implementation of TemplateSlotDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2004 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2004 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -273,14 +273,14 @@ TemplateSlotDialog::createContents(
 
     wxString *strs3 = (wxString*) NULL;
     wxChoice *item3 = new wxChoice( parent, ID_SLOT, wxDefaultPosition, wxSize(150,-1), 0, strs3, 0 );
-    item1->Add( item3, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_DESTINATION, wxT("Destination:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_DESTINATION, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );
-    item1->Add( item5, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -288,10 +288,10 @@ TemplateSlotDialog::createContents(
     wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
     item1->Add( item7, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
-    item0->Add( item1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item1, 0, wxGROW | wxALL, 5);
 
     wxStaticLine *item8 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
-    item0->Add( item8, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item8, 0, wxGROW | wxALL, 5);
 
     wxFlexGridSizer *item9 = new wxFlexGridSizer( 2, 0, 0 );
 
@@ -308,7 +308,7 @@ TemplateSlotDialog::createContents(
 
     item9->Add( item11, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
 
-    item0->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item9, 0, wxGROW | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/TemplateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateSlotDialog.cc
@@ -269,21 +269,21 @@ TemplateSlotDialog::createContents(
     wxFlexGridSizer *item1 = new wxFlexGridSizer( 2, 0, 0 );
 
     wxStaticText *item2 = new wxStaticText( parent, ID_LABEL_SLOT, wxT("Slot:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item2, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item2, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs3 = (wxString*) NULL;
     wxChoice *item3 = new wxChoice( parent, ID_SLOT, wxDefaultPosition, wxSize(150,-1), 0, strs3, 0 );
     item1->Add(item3, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item4 = new wxStaticText( parent, ID_LABEL_DESTINATION, wxT("Destination:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item4, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxString *strs5 = (wxString*) NULL;
     wxChoice *item5 = new wxChoice( parent, ID_DESTINATION, wxDefaultPosition, wxSize(100,-1), 0, strs5, 0 );
     item1->Add(item5, 0, wxGROW | wxALL, 5);
 
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
-    item1->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
     item1->Add( item7, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
@@ -306,7 +306,7 @@ TemplateSlotDialog::createContents(
     wxButton *item13 = new wxButton( parent, wxID_CANCEL, wxT("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     item11->Add( item13, 0, wxALIGN_CENTER|wxALL, 5 );
 
-    item9->Add( item11, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5 );
+    item9->Add(item11, 0, wxALIGN_RIGHT, 5);
 
     item0->Add(item9, 0, wxGROW | wxALL, 5);
 

--- a/tce/src/procgen/ProDe/TemplateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateSlotDialog.cc
@@ -285,7 +285,9 @@ TemplateSlotDialog::createContents(
     wxStaticText *item6 = new wxStaticText( parent, ID_LABEL_WIDTH, wxT("Width:"), wxDefaultPosition, wxDefaultSize, 0 );
     item1->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
-    wxSpinCtrl *item7 = new wxSpinCtrl( parent, ID_WIDTH, wxT("1"), wxDefaultPosition, wxSize(100,-1), 0, 1, 10000, 1 );
+    wxSpinCtrl *item7 =
+        new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition,
+                       wwxDefaultSize, 0, 1, 10000, 1);
     item1->Add( item7, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     item0->Add(item1, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/TemplateSlotDialog.cc
+++ b/tce/src/procgen/ProDe/TemplateSlotDialog.cc
@@ -287,7 +287,7 @@ TemplateSlotDialog::createContents(
 
     wxSpinCtrl *item7 =
         new wxSpinCtrl(parent, ID_WIDTH, wxT("1"), wxDefaultPosition,
-                       wwxDefaultSize, 0, 1, 10000, 1);
+                       wxDefaultSize, 0, 1, 10000, 1);
     item1->Add( item7, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
     item0->Add(item1, 0, wxGROW | wxALL, 5);

--- a/tce/src/procgen/ProDe/ValidateMachineDialog.cc
+++ b/tce/src/procgen/ProDe/ValidateMachineDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of ValidateMachineDialog class.
  *
- * @author Veli-Pekka J��skel�inen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 

--- a/tce/src/procgen/ProDe/ValidateMachineDialog.cc
+++ b/tce/src/procgen/ProDe/ValidateMachineDialog.cc
@@ -189,13 +189,13 @@ ValidateMachineDialog::createContents(
     wxStaticBoxSizer *item2 = new wxStaticBoxSizer( item3, wxVERTICAL );
 
     wxCheckBox *item4 = new wxCheckBox( parent, ID_CHECK_ANSI_C, wxT("Check for operations needed to support ANSI C."), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item4, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item4, 0, wxALL, 5);
 
     wxCheckBox *item5 = new wxCheckBox( parent, ID_CHECK_GLOBAL_CONN_REGISTER, wxT("Check for global connection register."), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item5, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item5, 0, wxALL, 5);
 
     wxButton *item6 = new wxButton( parent, ID_VALIDATE, wxT("Validate"), wxDefaultPosition, wxDefaultSize, 0 );
-    item2->Add( item6, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item2->Add(item6, 0, wxALIGN_RIGHT | wxALL, 5);
 
     item1->Add( item2, 0, wxGROW|wxALL, 5 );
 
@@ -215,7 +215,7 @@ ValidateMachineDialog::createContents(
     item0->Add(item10, 0, wxGROW | wxALL, 5);
 
     wxButton *item11 = new wxButton( parent, ID_CLOSE, wxT("Close"), wxDefaultPosition, wxDefaultSize, 0 );
-    item0->Add( item11, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item11, 0, wxALIGN_RIGHT | wxALL, 5);
 
     if (set_sizer)
     {

--- a/tce/src/procgen/ProDe/ValidateMachineDialog.cc
+++ b/tce/src/procgen/ProDe/ValidateMachineDialog.cc
@@ -26,7 +26,7 @@
  *
  * Definition of ValidateMachineDialog class.
  *
- * @author Veli-Pekka Jääskeläinen 2006 (vjaaskel-no.spam-cs.tut.fi)
+ * @author Veli-Pekka Jï¿½ï¿½skelï¿½inen 2006 (vjaaskel-no.spam-cs.tut.fi)
  * @note rating: red
  */
 
@@ -205,14 +205,14 @@ ValidateMachineDialog::createContents(
     resultsWindow_ = new wxHtmlWindow(parent, ID_RESULTS, wxDefaultPosition, wxSize(250, 250));
     wxWindow* item9 = resultsWindow_;
     wxASSERT( item9 );
-    item7->Add( item9, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item7->Add(item9, 0, wxGROW | wxALL, 5);
 
-    item1->Add( item7, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item1->Add(item7, 0, wxGROW | wxALL, 5);
 
     item0->Add( item1, 0, wxGROW|wxALL, 5 );
 
     wxStaticLine *item10 = new wxStaticLine( parent, ID_LINE, wxDefaultPosition, wxSize(20,-1), wxLI_HORIZONTAL );
-    item0->Add( item10, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+    item0->Add(item10, 0, wxGROW | wxALL, 5);
 
     wxButton *item11 = new wxButton( parent, ID_CLOSE, wxT("Close"), wxDefaultPosition, wxDefaultSize, 0 );
     item0->Add( item11, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5 );


### PR DESCRIPTION
Redone w/ strictly limited formatting changes. Note that apparent author name replacements are needed due to Visual Studio Code mis-converting the names into UTF-8.

Fixes #140 