### PR TITLE
functions_of_interest to the DSE

### DIFF
--- a/openasip/doc/man/OpenASIP/OpenASIP.tex
+++ b/openasip/doc/man/OpenASIP/OpenASIP.tex
@@ -9052,17 +9052,20 @@ evaluating hundreds or even thousands of processor configurations.
 
 \textbf{Output}: ExpResDB (Section~\ref{sec:expresdb})
 
-\subsection{Explorer Application format}
+\subsection{Explorer Application Directory}
 
-Applications are given as directories that contain the application specific
-files to the Explorer. Below is a description of all the possible files inside
-the application directory.
+Software applications that drive the design space exploration are given as folders
+that contain the application specific files to the Explorer. Below is a description
+of all the possible files inside the application directory.
 
 \begin{tabular}{p{0.25\textwidth}p{0.60\textwidth}}
 \textbf{file name} &\textbf{Description} \\
 \hline
 program.bc & The program byte code (produced using ``\verb|oacc --emit-llvm|'').\\
 description.txt & The application description.\\
+functions\_of\_interest & Comma separated list of functions in the program
+that should be (exclusively) included in the execution time measurement. This
+file is optional. If not given, the whole application's execution time is used. \\
 simulate.ttasim & TTASIM simulation script piped to the TTASIM to produce
 ttasim.out file. If no such file is given the simulation is started with
 "until 0" command.\\

--- a/openasip/src/applibs/dsdb/TestApplication.cc
+++ b/openasip/src/applibs/dsdb/TestApplication.cc
@@ -45,10 +45,12 @@ const string TestApplication::DESCRIPTION_FILE_NAME_ = "description.txt";
 const string TestApplication::APPLICATION_BASE_FILE_NAME_ = "program";
 const string TestApplication::SETUP_FILE_NAME_ = "setup.sh";
 const string TestApplication::SIMULATE_TTASIM_FILE_NAME_ = "simulate.ttasim";
-const string 
-TestApplication::CORRECT_OUTPUT_FILE_NAME_ = "correct_simulation_output";
+const string TestApplication::CORRECT_OUTPUT_FILE_NAME_ =
+    "correct_simulation_output";
 const string TestApplication::VERIFY_FILE_NAME_ = "verify.sh";
 const string TestApplication::CLEANUP_FILE_NAME_ = "cleanup.sh";
+const string TestApplication::FUNCTIONS_OF_INTEREST_FILE_NAME_ =
+    "functions_of_interest";
 const string TestApplication::MAX_RUNTIME_ = "max_runtime";
 const int TestApplication::MAX_LINE_LENGTH_ = 512;
 
@@ -75,6 +77,16 @@ TestApplication::TestApplication(const string& testApplicationPath)
                 __FILE__, __LINE__, __func__, exception.errorMessage());
         }
         fclose(file);
+    }
+
+    if (hasFunctionsOfInterest()) {
+        std::ifstream f(
+            testApplicationPath_ + FileSystem::DIRECTORY_SEPARATOR +
+            FUNCTIONS_OF_INTEREST_FILE_NAME_);
+        std::string str(
+            (std::istreambuf_iterator<char>(f)),
+            std::istreambuf_iterator<char>());
+        functionsOfInterest_ = TCEString(str).split(",");
     }
 }
 
@@ -302,8 +314,19 @@ TestApplication::hasCleanupSimulation() const {
 }
 
 /**
+ * @return true if 'functions_of_interest' file is found in the application
+ * directory.
+ */
+bool
+TestApplication::hasFunctionsOfInterest() const {
+    return FileSystem::fileIsReadable(
+        testApplicationPath_ + FileSystem::DIRECTORY_SEPARATOR +
+        FUNCTIONS_OF_INTEREST_FILE_NAME_);
+}
+
+/**
  * Returns the application path in the test application directory.
- * 
+ *
  * If the file 'sequential_program' does not exists returns an empty string.
  *
  * @return The path of the 'sequential_program' file.

--- a/openasip/src/applibs/dsdb/TestApplication.hh
+++ b/openasip/src/applibs/dsdb/TestApplication.hh
@@ -27,21 +27,22 @@
  * Declaration of TestApplication class.
  *
  * @author Jari Mäntyneva 2007 (jari.mantyneva-no.spam-tut.fi)
- * @author Pekka Jääskeläinen 2012
+ * @author Pekka Jääskeläinen 2012, 2025
  * @note rating: red
  */
 
 #ifndef TTA_TEST_APPLICATION_HH
 #define TTA_TEST_APPLICATION_HH
 
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
-#include "Exception.hh"
 
+#include "Exception.hh"
+#include "TCEString.hh"
 
 /**
- * Class for handling files in test application directory. 
+ * Class for handling files in test application directory.
  */
 class TestApplication {
 public:
@@ -59,6 +60,7 @@ public:
     bool hasCorrectOutput() const;
     bool hasVerifySimulation() const;
     bool hasCleanupSimulation() const;
+    bool hasFunctionsOfInterest() const;
     bool isValid() const { 
         return hasApplication() && 
             (hasCorrectOutput() || hasVerifySimulation());
@@ -72,12 +74,18 @@ public:
     void cleanupSimulation() const;
     ClockCycles cycleCount() const;
     Runtime maxRuntime() const;
+    const std::vector<TCEString>&
+    functionsOfInterest() const {
+        return functionsOfInterest_;
+    }
 
 private:
     /// Path of the test application directory.
     const std::string testApplicationPath_;
     /// Maximum runtime of the test appication in nano seconds
     Runtime maxRuntime_;
+    /// The names of the functions of interest (in terms of cycle count).
+    std::vector<TCEString> functionsOfInterest_;
 
     /// File name of the description text for the application.
     static const std::string DESCRIPTION_FILE_NAME_;
@@ -96,6 +104,11 @@ private:
     static const std::string VERIFY_FILE_NAME_;
     /// Name of the clean up file.
     static const std::string CLEANUP_FILE_NAME_;
+    /// Name of the file that has a comma separated list of functions of
+    /// interest for the cycle count measurements in the given app.
+    /// The exclusive profile of these functions will be used as the
+    /// cycle count in evaluation.
+    static const std::string FUNCTIONS_OF_INTEREST_FILE_NAME_;
     /// Name of the file that contains maximum runtime.
     static const std::string MAX_RUNTIME_;
     /// Maximum line length in a file.

--- a/openasip/src/applibs/mach/MachineConnectivityCheck.cc
+++ b/openasip/src/applibs/mach/MachineConnectivityCheck.cc
@@ -968,6 +968,9 @@ bool MachineConnectivityCheck::raConnected(const TTAMachine::Machine& machine) {
     static bool spammed = false;
     // check connection from RA to jump for fn return.
     ControlUnit& cu = *machine.controlUnit();
+
+    if (cu.returnAddressPort() == nullptr) return true;
+
     SpecialRegisterPort& ra = *cu.returnAddressPort();
     if (cu.hasOperation("jump")) {
         auto jumpOp = cu.operation("jump");


### PR DESCRIPTION
It's an application descriptor file that can be used to set the functions of interest in the simulated program.  If given, only the time spent in the chosen functions is included in the execution time that guides the design space exploration.

This is useful for cases where the main() contains printouts and verification code which then launches the actual function to optimize for.