### PR TITLE
Fix Boost 1.90/GCC 15, LLVM 22 linking, and Make 4.4+ unit-test races

### DIFF
--- a/openasip/configure.ac
+++ b/openasip/configure.ac
@@ -563,7 +563,10 @@ case "$LLVM_VERSION" in
      LLVM_VERSION=22
      LLVM_LIBRARYVERSION=22
      LLVM_SHARED_LIB_FILE=$LLVM_LIBDIR/libLLVM-$LLVM_LIBRARYVERSION$LIBRARY_SUFFIX
-     LLVM_SHARED_LIB=-lLLVM-${LLVM_LIBRARYVERSION}
+     # Prefer the TCE-built shared library SONAME so a system
+     # libLLVM-22.so (Debian/Ubuntu) is not picked up when -L/usr/lib
+     # precedes the custom LLVM libdir.
+     LLVM_SHARED_LIB=-lLLVMTCE
      LLVM_LDFLAGS="$($llvmConf --ldflags) $LLVM_SHARED_LIB"
      # The upstream LLVM doesn't (yet) have the RISC-V customization support.
      ENABLE_RISCV=true

--- a/openasip/src/applibs/HWGen/HDLGenerator.hh
+++ b/openasip/src/applibs/HWGen/HDLGenerator.hh
@@ -487,7 +487,8 @@ namespace HDLGenerator {
             return wireType_ == WireType::Vector || width_ > 1;
         }
 
-        WireType wireType() {
+        using Generatable::wireType;
+        WireType wireType() const override {
             return wireType_;
         }
 

--- a/openasip/src/applibs/Scheduler/ProgramRepresentations/PDG/ProgramDependenceGraph.cc
+++ b/openasip/src/applibs/Scheduler/ProgramRepresentations/PDG/ProgramDependenceGraph.cc
@@ -38,6 +38,8 @@
 // warnings
 #include "hash_set.hh"
 
+#include "CompilerWarnings.hh"
+IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
 #include <boost/graph/depth_first_search.hpp>
 #include <boost/graph/properties.hpp>
 #include <boost/graph/strong_components.hpp>

--- a/openasip/src/applibs/Simulator/CompiledSimController.cc
+++ b/openasip/src/applibs/Simulator/CompiledSimController.cc
@@ -332,7 +332,7 @@ CompiledSimController::programCounter() const {
  * @return The address of the last executed instruction
  */
 InstructionAddress
-CompiledSimController::lastExecutedInstruction() const {
+CompiledSimController::lastExecutedInstruction(int /*coreId*/) const {
     return simulation_->lastExecutedInstruction();
 }
 

--- a/openasip/src/applibs/Simulator/CompiledSimController.hh
+++ b/openasip/src/applibs/Simulator/CompiledSimController.hh
@@ -68,7 +68,7 @@ public:
     virtual void reset();
 
     virtual InstructionAddress programCounter() const;
-    virtual InstructionAddress lastExecutedInstruction() const;
+    virtual InstructionAddress lastExecutedInstruction(int coreId = -1) const;
     virtual ClockCycleCount clockCount() const;
 
     virtual boost::shared_ptr<CompiledSimulation> compiledSimulation();

--- a/openasip/src/applibs/Simulator/SimulatorFrontend.cc
+++ b/openasip/src/applibs/Simulator/SimulatorFrontend.cc
@@ -1430,6 +1430,10 @@ SimulatorFrontend::initializeTracing() {
         procedureTransferTracing_ || saveProfileData_ || 
         saveUtilizationData_ || busTracing_) {
 
+// GCC 15 false positive: -Wstringop-overflow on std::vector::resize to a
+// small size (coreCount == 1). Related to the known libstdc++ warning for
+// short vector reallocations; see also the note on traceDBOwned_.
+IGNORE_COMPILER_WARNING("-Wstringop-overflow")
         int coreCount = 1;
         
         traceDBs_.resize(coreCount, NULL);
@@ -1438,6 +1442,7 @@ SimulatorFrontend::initializeTracing() {
         rfAccessTrackers_.resize(coreCount, NULL);
         procedureTransferTrackers_.resize(coreCount, NULL);
         busTrackers_.resize(coreCount, NULL);
+POP_COMPILER_DIAGS
         for (int core = 0; core < 1; ++core) {
 
             ExecutionTrace* traceDB = traceDBs_.at(core);

--- a/openasip/src/tools/FileSystem.icc
+++ b/openasip/src/tools/FileSystem.icc
@@ -30,10 +30,7 @@
  * @author Esa Määttä 2007 (esa.maatta-no.spam-tut.fi)
  */
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/convenience.hpp>
-#include <boost/filesystem/exception.hpp>
-#include <boost/version.hpp>
+#include <filesystem>
 
 #include "CompilerWarnings.hh"
 IGNORE_CLANG_WARNING("-Wkeyword-macro")
@@ -216,14 +213,6 @@ FileSystem::findFromDirectoryRecursive(
 
     const boost::regex re(regex, boost::regex::perl|boost::regex::icase);
 
-#if BOOST_VERSION < 103302
-    const boost::regex reb("^\\..*|.*/\\..*",
-        boost::regex::perl|boost::regex::icase);
-    if (regex_match(directory, reb)) {
-        return false;
-    }   
-#endif
-
     if (!exists(Path(directory))) {
         return false;
     }
@@ -231,12 +220,6 @@ FileSystem::findFromDirectoryRecursive(
     directory_iterator dirIt(directory);
     directory_iterator endIt;
     while (dirIt != endIt) {
-#if BOOST_VERSION < 103302
-        if (regex_match((*dirIt).string(), reb)) {
-            ++dirIt;
-            continue;
-        }   
-#endif
         if (regex_match((*dirIt).path().string(), re)) {
             found.push_back((*dirIt).path().string());
         }

--- a/openasip/test/Makefile_test.defs
+++ b/openasip/test/Makefile_test.defs
@@ -107,7 +107,27 @@ TCE_LIBS = $(shell find ${TOP_SRCDIR}/src -name "libopenasip${LIBRARY_SUFFIX}" |
 # This is required to avoid make deleting the "intermediate" files,
 # which is required to rerun the test without building.
 .SECONDARY: $(patsubst %.rt,%-runner, ${TESTS})
-.NOTPARALLEL: ${GCOV_TEST} ${INITIALIZATION} ${TESTS} ${GCOV_TEST2} ${FINALIZATION}
+
+# Serialize this Makefile. Relying on ".NOTPARALLEL: <targets>" is not
+# enough with GNU Make 4.4+: those targets can still be started together
+# under -j, so FINALIZATION (cleanup) races with TESTS and deletes
+# fixtures such as data/tmp_*.hdb while the runner is still using them.
+.NOTPARALLEL:
+
+# Ensure init -> tests -> cleanup even if a future make changes
+# .NOTPARALLEL semantics again.
+ifneq ($(strip ${FINALIZATION}),)
+${FINALIZATION}: ${TESTS} ${GCOV_TEST2}
+endif
+ifneq ($(strip ${GCOV_TEST2}),)
+${GCOV_TEST2}: ${TESTS}
+endif
+ifneq ($(strip ${TESTS}),)
+${TESTS}: ${INITIALIZATION} ${GCOV_TEST}
+endif
+ifneq ($(strip ${INITIALIZATION}),)
+${INITIALIZATION}: ${GCOV_TEST}
+endif
 
 all: ${GCOV_TEST} ${INITIALIZATION} ${TESTS} ${GCOV_TEST2} ${FINALIZATION}
 


### PR DESCRIPTION
## Summary
- Boost 1.90 / GCC 15 warning fixes (`FileSystem.icc` `std::filesystem`, overloaded-virtual, GCC 15 false-positive suppressions)
- LLVM 22: link `-lLLVMTCE` instead of `-lLLVM-22` so system libLLVM isn't mixed with TCE-patched LLVM (unit test aborts)
- Unit-test Makefile: bare `.NOTPARALLEL` + init/test/cleanup deps for GNU Make 4.4+ race where cleanup deletes fixtures mid-run

## Test plan
- [x] `make` builds cleanly with Boost 1.90 / GCC 15 / LLVM 22
- [x] `make` under `openasip/test` (unit tests) passes
- [x] `systemtest.py -os` when feasible