### PR TITLE
Skip GHDL-dependent ProGe systemtests when ghdl is missing

### DIFF
--- a/testsuite/systemtest/procgen/ProGe/tcetest_sram_rf/initialize
+++ b/testsuite/systemtest/procgen/ProGe/tcetest_sram_rf/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch tcetest_sram_rf.sh.disabled
+fi

--- a/testsuite/systemtest/procgen/ProGe/tcetest_sram_rf/initialize
+++ b/testsuite/systemtest/procgen/ProGe/tcetest_sram_rf/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f tcetest_sram_rf.sh.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_all_generated_ops/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_all_generated_ops/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f tcetest_all_generated_ops.sh.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_all_generated_ops/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_all_generated_ops/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch tcetest_all_generated_ops.sh.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_execution_bus_trace/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_execution_bus_trace/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch tcetest_execution_bus_trace.sh.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_execution_bus_trace/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_execution_bus_trace/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f tcetest_execution_bus_trace.sh.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_compression/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_compression/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch test_fft_case_with_compression.testdesc.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_compression/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_compression/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f test_fft_case_with_compression.testdesc.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f test_fft_case_with_limm.testdesc.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch test_fft_case_with_limm.testdesc.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm_opt/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm_opt/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch test_fft_case_with_limm_opt.testdesc.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm_opt/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_limm_opt/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f test_fft_case_with_limm_opt.testdesc.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_move_slot_compression/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_move_slot_compression/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f test_fft_case_with_move_slot_compression.testdesc.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_move_slot_compression/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_move_slot_compression/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch test_fft_case_with_move_slot_compression.testdesc.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_simm/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_simm/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f test_fft_case_with_simm.testdesc.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_simm/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_fft_case_with_simm/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch test_fft_case_with_simm.testdesc.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_generate_debugger/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_generate_debugger/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f tcetest_generate_debugger.sh.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_generate_debugger/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_generate_debugger/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch tcetest_generate_debugger.sh.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_le_machine/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_le_machine/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch tcetest_le_machine.sh.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_le_machine/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_le_machine/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f tcetest_le_machine.sh.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_point_to_point_encoding/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_point_to_point_encoding/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f tcetest_point_to_point_encoding.sh.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_point_to_point_encoding/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_point_to_point_encoding/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch tcetest_point_to_point_encoding.sh.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_test_generator/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_test_generator/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f tcetest_test_generator.sh.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_test_generator/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_test_generator/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch tcetest_test_generator.sh.disabled
+fi

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_verify_limm_operation/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_verify_limm_operation/initialize
@@ -1,7 +1,7 @@
 #!/bin/bash
 # disable the test if GHDL is not installed on the machine
 
-rm -f *.disabled
+rm -f verify_limm_operation.testdesc.disabled
 
 ghdl_bin=$(which ghdl 2> /dev/null)
 if [ "x${ghdl_bin}" == "x" ]; then

--- a/testsuite/systemtest_long/procgen/ProGe/tcetest_verify_limm_operation/initialize
+++ b/testsuite/systemtest_long/procgen/ProGe/tcetest_verify_limm_operation/initialize
@@ -1,0 +1,9 @@
+#!/bin/bash
+# disable the test if GHDL is not installed on the machine
+
+rm -f *.disabled
+
+ghdl_bin=$(which ghdl 2> /dev/null)
+if [ "x${ghdl_bin}" == "x" ]; then
+    touch verify_limm_operation.testdesc.disabled
+fi


### PR DESCRIPTION
## Summary
- Skip GHDL-dependent ProGe systemtests when `ghdl` is not available on PATH, so environments without GHDL can still run the rest of the suite.
- Avoids hard failures for SRAM RF / ProGe flows that require HDL simulation via GHDL.

## Test plan
- [x] Without `ghdl` on PATH, run initialize/setup scripts related to `sram_rf` and confirm GHDL-dependent cases are skipped (not failed).
- [x] With `ghdl` available, confirm the same ProGe / `sram_rf` tests still run as before.
- [x] Spot-check long ProGe systemtests (`systemtest_long` / ProGe) under both conditions to ensure skip vs execute behavior is correct.
- [x] Confirm CI (or a local full systemtest pass without GHDL) no longer fails solely due to missing `ghdl`.


Made with [Cursor](https://cursor.com)